### PR TITLE
docs: add ABOUTME comments to all Python files

### DIFF
--- a/src/gc2_connect/__init__.py
+++ b/src/gc2_connect/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Root package for GC2 Connect Desktop application.
+# ABOUTME: Provides integration between Foresight GC2 launch monitor and GSPro golf simulator.

--- a/src/gc2_connect/config/__init__.py
+++ b/src/gc2_connect/config/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Configuration and settings package for GC2 Connect.
+# ABOUTME: Handles persistent settings storage and application configuration.

--- a/src/gc2_connect/gc2/__init__.py
+++ b/src/gc2_connect/gc2/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: GC2 launch monitor communication package.
+# ABOUTME: Contains USB reader for connecting to and reading data from the GC2 device.

--- a/src/gc2_connect/gc2/usb_reader.py
+++ b/src/gc2_connect/gc2/usb_reader.py
@@ -1,3 +1,5 @@
+# ABOUTME: USB communication handler for the Foresight GC2 launch monitor.
+# ABOUTME: Reads shot data via USB bulk transfer and provides mock reader for testing.
 """GC2 USB communication handler."""
 
 from __future__ import annotations

--- a/src/gc2_connect/gspro/__init__.py
+++ b/src/gc2_connect/gspro/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: GSPro golf simulator integration package.
+# ABOUTME: Contains client for communicating with GSPro via Open Connect API v1.

--- a/src/gc2_connect/gspro/client.py
+++ b/src/gc2_connect/gspro/client.py
@@ -1,3 +1,5 @@
+# ABOUTME: TCP client for GSPro Open Connect API v1.
+# ABOUTME: Sends shot data to GSPro golf simulator and handles responses.
 """GSPro Open Connect API v1 client."""
 
 from __future__ import annotations

--- a/src/gc2_connect/main.py
+++ b/src/gc2_connect/main.py
@@ -1,3 +1,5 @@
+# ABOUTME: Main entry point for the GC2 Connect Desktop application.
+# ABOUTME: Launches the NiceGUI web interface for GC2-to-GSPro integration.
 """GC2 Connect - Main entry point."""
 
 from gc2_connect.ui.app import main

--- a/src/gc2_connect/models.py
+++ b/src/gc2_connect/models.py
@@ -1,3 +1,5 @@
+# ABOUTME: Pydantic/dataclass models for GC2 shot data and GSPro API messages.
+# ABOUTME: Handles data parsing, validation, and conversion between GC2 and GSPro formats.
 """Data models for GC2 shot data and GSPro messages."""
 
 from __future__ import annotations

--- a/src/gc2_connect/ui/__init__.py
+++ b/src/gc2_connect/ui/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: User interface package for GC2 Connect.
+# ABOUTME: Contains NiceGUI-based web interface for monitoring and controlling the application.

--- a/src/gc2_connect/ui/app.py
+++ b/src/gc2_connect/ui/app.py
@@ -1,3 +1,5 @@
+# ABOUTME: NiceGUI web-based user interface for GC2 Connect.
+# ABOUTME: Displays connection status, shot data, history, and provides manual controls.
 """GC2 Connect - NiceGUI Application."""
 
 from __future__ import annotations

--- a/todo.md
+++ b/todo.md
@@ -17,9 +17,9 @@ Started: 2025-12-30
   - [x] Create smoke test
   - [x] Verify all tools work
 
-- [ ] **Prompt 2**: Add ABOUTME Comments
-  - [ ] Add comments to all Python files
-  - [ ] Verify linting passes
+- [x] **Prompt 2**: Add ABOUTME Comments
+  - [x] Add comments to all Python files
+  - [x] Verify linting passes
 
 - [ ] **Prompt 3**: Unit Tests for Data Models
   - [ ] Test GC2ShotData

--- a/tools/mock_gspro_server.py
+++ b/tools/mock_gspro_server.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# ABOUTME: Mock GSPro server for testing GC2 Connect without actual GSPro software.
+# ABOUTME: Accepts shot data, logs it, and returns success responses.
 """Mock GSPro server for testing without GSPro."""
 
 import argparse


### PR DESCRIPTION
## Summary
- Add 2-line ABOUTME comments to all Python source files explaining their purpose
- Comments follow the required format: `# ABOUTME: <description>`
- All 11 source files now have descriptive header comments

## Files Updated
- `src/gc2_connect/__init__.py` - Root package
- `src/gc2_connect/main.py` - Entry point
- `src/gc2_connect/models.py` - Data models
- `src/gc2_connect/gc2/__init__.py` - GC2 package
- `src/gc2_connect/gc2/usb_reader.py` - USB communication
- `src/gc2_connect/gspro/__init__.py` - GSPro package  
- `src/gc2_connect/gspro/client.py` - TCP client
- `src/gc2_connect/ui/__init__.py` - UI package
- `src/gc2_connect/ui/app.py` - NiceGUI application
- `src/gc2_connect/config/__init__.py` - Config package
- `tools/mock_gspro_server.py` - Test server

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run pytest` passes (5 tests)