### PR TITLE
feat: integrate settings into UI

### DIFF
--- a/tests/integration/test_settings_ui.py
+++ b/tests/integration/test_settings_ui.py
@@ -1,0 +1,249 @@
+# ABOUTME: Integration tests for Settings integration with UI.
+# ABOUTME: Tests that settings are loaded on startup and saved when changed.
+"""Integration tests for Settings and UI integration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from gc2_connect.ui.app import GC2ConnectApp
+
+
+class TestSettingsLoadOnInit:
+    """Tests for loading settings on app initialization."""
+
+    def test_app_loads_settings_on_init(self, tmp_path: Path) -> None:
+        """Test that GC2ConnectApp loads settings on initialization."""
+        settings_path = tmp_path / "settings.json"
+        settings_data = {
+            "version": 1,
+            "gspro": {"host": "10.0.0.50", "port": 8888, "auto_connect": True},
+            "gc2": {"auto_connect": False, "reject_zero_spin": True, "use_mock": True},
+            "ui": {"theme": "light", "show_history": True, "history_limit": 100},
+        }
+        settings_path.write_text(json.dumps(settings_data))
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+
+        assert app.settings is not None
+        assert app.settings.gspro.host == "10.0.0.50"
+        assert app.settings.gspro.port == 8888
+        assert app.settings.gc2.use_mock is True
+        assert app.settings.ui.history_limit == 100
+
+    def test_app_uses_default_settings_if_file_missing(self, tmp_path: Path) -> None:
+        """Test that app uses defaults if settings file doesn't exist."""
+        settings_path = tmp_path / "nonexistent" / "settings.json"
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+
+        assert app.settings is not None
+        assert app.settings.gspro.host == "127.0.0.1"
+        assert app.settings.gspro.port == 921
+        assert app.settings.gc2.use_mock is False
+
+    def test_app_initializes_state_from_settings(self, tmp_path: Path) -> None:
+        """Test that app state is initialized from loaded settings."""
+        settings_path = tmp_path / "settings.json"
+        settings_data = {
+            "version": 1,
+            "gspro": {"host": "192.168.1.200", "port": 5000, "auto_connect": False},
+            "gc2": {"auto_connect": True, "reject_zero_spin": False, "use_mock": True},
+            "ui": {"theme": "dark", "show_history": True, "history_limit": 25},
+        }
+        settings_path.write_text(json.dumps(settings_data))
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+
+        # State should match settings
+        assert app.use_mock_gc2 is True
+        assert app.history_limit == 25
+
+
+class TestSettingsInputValues:
+    """Tests for settings values being used in inputs."""
+
+    def test_gspro_host_from_settings(self, tmp_path: Path) -> None:
+        """Test that GSPro host input uses value from settings."""
+        settings_path = tmp_path / "settings.json"
+        settings_data = {
+            "version": 1,
+            "gspro": {"host": "custom.host.local", "port": 9999, "auto_connect": False},
+            "gc2": {"auto_connect": True, "reject_zero_spin": True, "use_mock": False},
+            "ui": {"theme": "dark", "show_history": True, "history_limit": 50},
+        }
+        settings_path.write_text(json.dumps(settings_data))
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+
+        # The app should have the custom values ready for when build_ui is called
+        assert app.settings.gspro.host == "custom.host.local"
+        assert app.settings.gspro.port == 9999
+
+
+class TestSettingsSave:
+    """Tests for saving settings when changed."""
+
+    def test_save_settings_persists_to_file(self, tmp_path: Path) -> None:
+        """Test that save_settings writes to file."""
+        settings_path = tmp_path / "settings.json"
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+
+            # Modify settings
+            app.settings.gspro.host = "new.host.com"
+            app.settings.gspro.port = 1234
+
+            # Save settings
+            app.save_settings()
+
+        # Verify file was written
+        assert settings_path.exists()
+        data = json.loads(settings_path.read_text())
+        assert data["gspro"]["host"] == "new.host.com"
+        assert data["gspro"]["port"] == 1234
+
+    def test_update_gspro_settings_saves(self, tmp_path: Path) -> None:
+        """Test that updating GSPro settings triggers save."""
+        settings_path = tmp_path / "settings.json"
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+            app.update_gspro_host("updated.host.com")
+            app.update_gspro_port(7777)
+
+        # Verify saved values
+        data = json.loads(settings_path.read_text())
+        assert data["gspro"]["host"] == "updated.host.com"
+        assert data["gspro"]["port"] == 7777
+
+    def test_update_gc2_settings_saves(self, tmp_path: Path) -> None:
+        """Test that updating GC2 settings triggers save."""
+        settings_path = tmp_path / "settings.json"
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+            app.update_use_mock(True)
+
+        # Verify saved values
+        data = json.loads(settings_path.read_text())
+        assert data["gc2"]["use_mock"] is True
+
+    def test_update_history_limit_saves(self, tmp_path: Path) -> None:
+        """Test that updating history limit triggers save."""
+        settings_path = tmp_path / "settings.json"
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+            app.update_history_limit(75)
+
+        # Verify saved values
+        data = json.loads(settings_path.read_text())
+        assert data["ui"]["history_limit"] == 75
+        assert app.history_limit == 75
+
+
+class TestSettingsRoundtrip:
+    """Tests for settings persistence across app restarts."""
+
+    def test_settings_persist_across_instances(self, tmp_path: Path) -> None:
+        """Test that settings saved by one instance are loaded by another."""
+        settings_path = tmp_path / "settings.json"
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            # First instance - modify and save settings
+            app1 = GC2ConnectApp()
+            app1.update_gspro_host("persistent.host.com")
+            app1.update_gspro_port(5555)
+            app1.update_use_mock(True)
+            app1.update_history_limit(99)
+
+            # Second instance - should load saved settings
+            app2 = GC2ConnectApp()
+
+        assert app2.settings.gspro.host == "persistent.host.com"
+        assert app2.settings.gspro.port == 5555
+        assert app2.settings.gc2.use_mock is True
+        assert app2.settings.ui.history_limit == 99
+        assert app2.use_mock_gc2 is True
+        assert app2.history_limit == 99
+
+
+class TestSettingsPath:
+    """Tests for settings file path display."""
+
+    def test_get_settings_path_available(self, tmp_path: Path) -> None:
+        """Test that app can provide settings path for display."""
+        settings_path = tmp_path / "settings.json"
+
+        with (
+            patch(
+                "gc2_connect.config.settings.get_settings_path",
+                return_value=settings_path,
+            ),
+            patch("gc2_connect.ui.app.get_settings_path", return_value=settings_path),
+        ):
+            app = GC2ConnectApp()
+            # Must call within the patch context
+            assert app.get_settings_path() == settings_path

--- a/todo.md
+++ b/todo.md
@@ -47,10 +47,10 @@ Started: 2025-12-30
   - [x] Platform-specific paths
   - [x] Load/save functionality
 
-- [ ] **Prompt 7**: Integrate Settings into UI
-  - [ ] Load settings on startup
-  - [ ] Save settings on change
-  - [ ] Add settings panel
+- [x] **Prompt 7**: Integrate Settings into UI
+  - [x] Load settings on startup
+  - [x] Save settings on change
+  - [x] Add settings panel
 
 ---
 


### PR DESCRIPTION
## Summary

Integrate the Settings module into the NiceGUI application (Prompt 7).

### Changes
- **Load settings on startup**: Settings are loaded in `GC2ConnectApp.__init__()` and used to initialize state
- **Initialize inputs with saved values**: GSPro host/port inputs now use values from settings
- **Auto-save on change**: Settings are saved automatically when values change
- **Settings panel**: New collapsible panel with:
  - History limit configuration (10-500 shots)
  - Auto-connect toggles for GC2 and GSPro
  - Settings file location display
  - Explicit "Save Settings" button

### New Methods on `GC2ConnectApp`
- `save_settings()` - Save current settings to file
- `get_settings_path()` - Get path to settings file
- `update_gspro_host()` / `update_gspro_port()` - Update and save GSPro settings
- `update_use_mock()` - Update and save mock GC2 setting
- `update_history_limit()` - Update and save history limit

### Files Modified
- `src/gc2_connect/ui/app.py` - Added settings integration
- `tests/integration/test_settings_ui.py` - 10 new integration tests

## Test plan

- [x] All 175 tests pass (`uv run pytest`)
- [x] Ruff linting passes (`uv run ruff check .`)
- [x] Settings persist across app restarts
- [x] Input changes trigger auto-save