### PR TITLE
feat: add OpenGolfCoach library wrapper for shot calculations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "pywebview>=6.1",
+    "opengolfcoach>=0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -92,6 +93,7 @@ plugins = ["pydantic.mypy"]
 module = [
     "usb.*",
     "nicegui.*",
+    "opengolfcoach",
 ]
 ignore_missing_imports = true
 

--- a/src/gc2_connect/open_range/physics/opengolfcoach_wrapper.py
+++ b/src/gc2_connect/open_range/physics/opengolfcoach_wrapper.py
@@ -1,0 +1,193 @@
+# ABOUTME: Wrapper module for OpenGolfCoach library integration.
+# ABOUTME: Provides Python-friendly interface to the Rust/WASM physics calculations.
+"""Wrapper module for OpenGolfCoach library.
+
+This module provides a Python-friendly interface to the OpenGolfCoach library,
+which is a Rust/WebAssembly library with Python bindings. It calculates derived
+shot values including shot classification, ranking, distances, and estimated
+club data from ball data.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+try:
+    import opengolfcoach
+
+    _OPENGOLFCOACH_AVAILABLE = True
+except ImportError:
+    _OPENGOLFCOACH_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from gc2_connect.models import GC2ShotData
+
+
+def is_available() -> bool:
+    """Check if OpenGolfCoach library is available.
+
+    Returns:
+        True if the library is installed and can be imported.
+    """
+    return _OPENGOLFCOACH_AVAILABLE
+
+
+@dataclass
+class OpenGolfCoachInput:
+    """Input parameters for OpenGolfCoach calculation."""
+
+    ball_speed_meters_per_second: float
+    vertical_launch_angle_degrees: float
+    horizontal_launch_angle_degrees: float = 0.0
+    total_spin_rpm: float = 0.0
+    spin_axis_degrees: float = 0.0
+
+    def to_json(self) -> str:
+        """Convert to JSON string for OpenGolfCoach.
+
+        Returns:
+            JSON string with all input parameters.
+        """
+        return json.dumps(
+            {
+                "ball_speed_meters_per_second": self.ball_speed_meters_per_second,
+                "vertical_launch_angle_degrees": self.vertical_launch_angle_degrees,
+                "horizontal_launch_angle_degrees": self.horizontal_launch_angle_degrees,
+                "total_spin_rpm": self.total_spin_rpm,
+                "spin_axis_degrees": self.spin_axis_degrees,
+            }
+        )
+
+    @classmethod
+    def from_gc2_shot(cls, shot: GC2ShotData) -> OpenGolfCoachInput:
+        """Create input from GC2ShotData.
+
+        Args:
+            shot: GC2 shot data from launch monitor.
+
+        Returns:
+            OpenGolfCoachInput with converted units.
+        """
+        # Convert mph to m/s (1 mph = 0.44704 m/s)
+        ball_speed_ms = shot.ball_speed * 0.44704
+
+        # Calculate total spin from back_spin and side_spin
+        total_spin = math.sqrt(shot.back_spin**2 + shot.side_spin**2)
+
+        # Calculate spin axis from components (using GC2ShotData.spin_axis property)
+        spin_axis = shot.spin_axis
+
+        return cls(
+            ball_speed_meters_per_second=ball_speed_ms,
+            vertical_launch_angle_degrees=shot.launch_angle,
+            horizontal_launch_angle_degrees=shot.horizontal_launch_angle,
+            total_spin_rpm=total_spin,
+            spin_axis_degrees=spin_axis,
+        )
+
+
+@dataclass
+class OpenGolfCoachResult:
+    """Output from OpenGolfCoach calculation."""
+
+    # Distance metrics (in meters from library)
+    carry_distance_meters: float
+    total_distance_meters: float
+    offline_distance_meters: float
+
+    # Spin components
+    backspin_rpm: float
+    sidespin_rpm: float
+
+    # Performance metrics
+    club_speed_meters_per_second: float | None
+    smash_factor: float | None
+    club_path_degrees: float | None
+    club_face_to_target_degrees: float | None
+    club_face_to_path_degrees: float | None
+
+    # Shot classification
+    shot_name: str
+    shot_rank: str
+    shot_color_rgb: str
+
+    @property
+    def carry_distance_yards(self) -> float:
+        """Carry distance converted to yards."""
+        return self.carry_distance_meters * 1.09361
+
+    @property
+    def total_distance_yards(self) -> float:
+        """Total distance converted to yards."""
+        return self.total_distance_meters * 1.09361
+
+    @property
+    def offline_distance_yards(self) -> float:
+        """Offline distance converted to yards."""
+        return self.offline_distance_meters * 1.09361
+
+    @property
+    def club_speed_mph(self) -> float | None:
+        """Club speed converted to mph, or None if not available."""
+        if self.club_speed_meters_per_second is None:
+            return None
+        return self.club_speed_meters_per_second * 2.23694
+
+
+def calculate_shot(input_data: OpenGolfCoachInput) -> OpenGolfCoachResult:
+    """Calculate derived values using OpenGolfCoach library.
+
+    Args:
+        input_data: Shot input parameters.
+
+    Returns:
+        OpenGolfCoachResult with calculated values.
+
+    Raises:
+        RuntimeError: If OpenGolfCoach library is not available.
+        ValueError: If calculation fails or returns invalid data.
+    """
+    if not _OPENGOLFCOACH_AVAILABLE:
+        raise RuntimeError("OpenGolfCoach library is not installed")
+
+    json_input = input_data.to_json()
+    json_output = opengolfcoach.calculate_derived_values(json_input)
+    result = json.loads(json_output)
+
+    # Extract values from the nested 'open_golf_coach' key
+    ogc = result.get("open_golf_coach", {})
+
+    return OpenGolfCoachResult(
+        carry_distance_meters=ogc.get("carry_distance_meters", 0.0),
+        total_distance_meters=ogc.get("total_distance_meters", 0.0),
+        offline_distance_meters=ogc.get("offline_distance_meters", 0.0),
+        backspin_rpm=ogc.get("backspin_rpm", 0.0),
+        sidespin_rpm=ogc.get("sidespin_rpm", 0.0),
+        club_speed_meters_per_second=ogc.get("club_speed_meters_per_second"),
+        smash_factor=ogc.get("smash_factor"),
+        club_path_degrees=ogc.get("club_path_degrees"),
+        club_face_to_target_degrees=ogc.get("club_face_to_target_degrees"),
+        club_face_to_path_degrees=ogc.get("club_face_to_path_degrees"),
+        shot_name=ogc.get("shot_name", "Unknown"),
+        shot_rank=ogc.get("shot_rank", "D"),
+        shot_color_rgb=ogc.get("shot_color_rgb", "#808080"),
+    )
+
+
+def calculate_shot_from_gc2(shot: GC2ShotData) -> OpenGolfCoachResult:
+    """Calculate derived values directly from GC2ShotData.
+
+    Args:
+        shot: GC2 shot data from launch monitor.
+
+    Returns:
+        OpenGolfCoachResult with calculated values.
+
+    Raises:
+        RuntimeError: If OpenGolfCoach library is not available.
+    """
+    input_data = OpenGolfCoachInput.from_gc2_shot(shot)
+    return calculate_shot(input_data)

--- a/tests/unit/test_opengolfcoach_wrapper.py
+++ b/tests/unit/test_opengolfcoach_wrapper.py
@@ -1,0 +1,442 @@
+# ABOUTME: Unit tests for OpenGolfCoach library wrapper.
+# ABOUTME: Tests input/output dataclasses, unit conversions, and calculation functions.
+"""Tests for OpenGolfCoach wrapper module."""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+
+class TestOpenGolfCoachInput:
+    """Tests for OpenGolfCoachInput dataclass."""
+
+    def test_creation_with_defaults(self) -> None:
+        """Test OpenGolfCoachInput creation with default values."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+        )
+
+        input_data = OpenGolfCoachInput(
+            ball_speed_meters_per_second=72.0,
+            vertical_launch_angle_degrees=12.0,
+        )
+        assert input_data.ball_speed_meters_per_second == 72.0
+        assert input_data.vertical_launch_angle_degrees == 12.0
+        assert input_data.horizontal_launch_angle_degrees == 0.0
+        assert input_data.total_spin_rpm == 0.0
+        assert input_data.spin_axis_degrees == 0.0
+
+    def test_creation_with_all_fields(self) -> None:
+        """Test OpenGolfCoachInput creation with all fields."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+        )
+
+        input_data = OpenGolfCoachInput(
+            ball_speed_meters_per_second=72.0,
+            vertical_launch_angle_degrees=12.0,
+            horizontal_launch_angle_degrees=2.5,
+            total_spin_rpm=2500.0,
+            spin_axis_degrees=5.0,
+        )
+        assert input_data.ball_speed_meters_per_second == 72.0
+        assert input_data.vertical_launch_angle_degrees == 12.0
+        assert input_data.horizontal_launch_angle_degrees == 2.5
+        assert input_data.total_spin_rpm == 2500.0
+        assert input_data.spin_axis_degrees == 5.0
+
+    def test_to_json_produces_valid_json(self) -> None:
+        """Test to_json() produces valid JSON with all required fields."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+        )
+
+        input_data = OpenGolfCoachInput(
+            ball_speed_meters_per_second=72.0,
+            vertical_launch_angle_degrees=12.0,
+            horizontal_launch_angle_degrees=2.5,
+            total_spin_rpm=2500.0,
+            spin_axis_degrees=5.0,
+        )
+        json_str = input_data.to_json()
+
+        parsed = json.loads(json_str)
+        assert parsed["ball_speed_meters_per_second"] == 72.0
+        assert parsed["vertical_launch_angle_degrees"] == 12.0
+        assert parsed["horizontal_launch_angle_degrees"] == 2.5
+        assert parsed["total_spin_rpm"] == 2500.0
+        assert parsed["spin_axis_degrees"] == 5.0
+
+    def test_from_gc2_shot_converts_units(self) -> None:
+        """Test from_gc2_shot() correctly converts mph to m/s."""
+        from gc2_connect.models import GC2ShotData
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+        )
+
+        gc2_shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=161.0,  # mph
+            launch_angle=12.0,
+            horizontal_launch_angle=2.5,
+            back_spin=2490.0,
+            side_spin=218.0,
+        )
+
+        input_data = OpenGolfCoachInput.from_gc2_shot(gc2_shot)
+
+        # 161 mph * 0.44704 = ~71.97 m/s
+        assert input_data.ball_speed_meters_per_second == pytest.approx(71.97, rel=0.01)
+        assert input_data.vertical_launch_angle_degrees == 12.0
+        assert input_data.horizontal_launch_angle_degrees == 2.5
+
+        # Total spin from components: sqrt(2490^2 + 218^2) = ~2499.5
+        expected_total_spin = math.sqrt(2490**2 + 218**2)
+        assert input_data.total_spin_rpm == pytest.approx(expected_total_spin, rel=0.01)
+
+    def test_from_gc2_shot_calculates_spin_axis(self) -> None:
+        """Test from_gc2_shot() calculates spin axis from components."""
+        from gc2_connect.models import GC2ShotData
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+        )
+
+        gc2_shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=150.0,
+            launch_angle=10.0,
+            horizontal_launch_angle=0.0,
+            back_spin=2000.0,
+            side_spin=500.0,
+        )
+
+        input_data = OpenGolfCoachInput.from_gc2_shot(gc2_shot)
+
+        # spin_axis = atan2(side_spin, back_spin) in degrees
+        expected_axis = math.degrees(math.atan2(500, 2000))
+        assert input_data.spin_axis_degrees == pytest.approx(expected_axis, rel=0.01)
+
+
+class TestOpenGolfCoachResult:
+    """Tests for OpenGolfCoachResult dataclass."""
+
+    def test_creation(self) -> None:
+        """Test OpenGolfCoachResult creation."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachResult,
+        )
+
+        result = OpenGolfCoachResult(
+            carry_distance_meters=226.3,
+            total_distance_meters=236.2,
+            offline_distance_meters=15.9,
+            backspin_rpm=2490.5,
+            sidespin_rpm=217.9,
+            club_speed_meters_per_second=48.4,
+            smash_factor=1.488,
+            club_path_degrees=0.48,
+            club_face_to_target_degrees=2.27,
+            club_face_to_path_degrees=1.79,
+            shot_name="Straight Fade",
+            shot_rank="A",
+            shot_color_rgb="0x00D977",
+        )
+        assert result.carry_distance_meters == 226.3
+        assert result.total_distance_meters == 236.2
+        assert result.shot_name == "Straight Fade"
+        assert result.shot_rank == "A"
+
+    def test_carry_distance_yards_conversion(self) -> None:
+        """Test carry_distance_yards property converts correctly."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachResult,
+        )
+
+        result = OpenGolfCoachResult(
+            carry_distance_meters=226.3,
+            total_distance_meters=236.2,
+            offline_distance_meters=15.9,
+            backspin_rpm=2490.0,
+            sidespin_rpm=218.0,
+            club_speed_meters_per_second=48.4,
+            smash_factor=1.488,
+            club_path_degrees=0.48,
+            club_face_to_target_degrees=2.27,
+            club_face_to_path_degrees=1.79,
+            shot_name="Straight Fade",
+            shot_rank="A",
+            shot_color_rgb="0x00D977",
+        )
+
+        # 226.3 meters * 1.09361 = ~247.5 yards
+        assert result.carry_distance_yards == pytest.approx(247.5, rel=0.01)
+
+    def test_total_distance_yards_conversion(self) -> None:
+        """Test total_distance_yards property converts correctly."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachResult,
+        )
+
+        result = OpenGolfCoachResult(
+            carry_distance_meters=226.3,
+            total_distance_meters=236.2,
+            offline_distance_meters=15.9,
+            backspin_rpm=2490.0,
+            sidespin_rpm=218.0,
+            club_speed_meters_per_second=48.4,
+            smash_factor=1.488,
+            club_path_degrees=0.48,
+            club_face_to_target_degrees=2.27,
+            club_face_to_path_degrees=1.79,
+            shot_name="Straight Fade",
+            shot_rank="A",
+            shot_color_rgb="0x00D977",
+        )
+
+        # 236.2 meters * 1.09361 = ~258.3 yards
+        assert result.total_distance_yards == pytest.approx(258.3, rel=0.01)
+
+    def test_offline_distance_yards_conversion(self) -> None:
+        """Test offline_distance_yards property converts correctly."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachResult,
+        )
+
+        result = OpenGolfCoachResult(
+            carry_distance_meters=226.3,
+            total_distance_meters=236.2,
+            offline_distance_meters=15.9,
+            backspin_rpm=2490.0,
+            sidespin_rpm=218.0,
+            club_speed_meters_per_second=48.4,
+            smash_factor=1.488,
+            club_path_degrees=0.48,
+            club_face_to_target_degrees=2.27,
+            club_face_to_path_degrees=1.79,
+            shot_name="Straight Fade",
+            shot_rank="A",
+            shot_color_rgb="0x00D977",
+        )
+
+        # 15.9 meters * 1.09361 = ~17.4 yards
+        assert result.offline_distance_yards == pytest.approx(17.4, rel=0.01)
+
+    def test_club_speed_mph_conversion(self) -> None:
+        """Test club_speed_mph property converts correctly."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachResult,
+        )
+
+        result = OpenGolfCoachResult(
+            carry_distance_meters=226.3,
+            total_distance_meters=236.2,
+            offline_distance_meters=15.9,
+            backspin_rpm=2490.0,
+            sidespin_rpm=218.0,
+            club_speed_meters_per_second=48.4,
+            smash_factor=1.488,
+            club_path_degrees=0.48,
+            club_face_to_target_degrees=2.27,
+            club_face_to_path_degrees=1.79,
+            shot_name="Straight Fade",
+            shot_rank="A",
+            shot_color_rgb="0x00D977",
+        )
+
+        # 48.4 m/s * 2.23694 = ~108.3 mph
+        assert result.club_speed_mph == pytest.approx(108.3, rel=0.01)
+
+    def test_club_speed_mph_none_when_not_available(self) -> None:
+        """Test club_speed_mph returns None when club_speed not available."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachResult,
+        )
+
+        result = OpenGolfCoachResult(
+            carry_distance_meters=226.3,
+            total_distance_meters=236.2,
+            offline_distance_meters=15.9,
+            backspin_rpm=2490.0,
+            sidespin_rpm=218.0,
+            club_speed_meters_per_second=None,
+            smash_factor=None,
+            club_path_degrees=None,
+            club_face_to_target_degrees=None,
+            club_face_to_path_degrees=None,
+            shot_name="Unknown",
+            shot_rank="D",
+            shot_color_rgb="#808080",
+        )
+
+        assert result.club_speed_mph is None
+
+
+class TestCalculateShot:
+    """Tests for calculate_shot() function."""
+
+    def test_calculate_shot_returns_valid_result(self) -> None:
+        """Test calculate_shot() returns OpenGolfCoachResult for typical shot."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+            calculate_shot,
+        )
+
+        input_data = OpenGolfCoachInput(
+            ball_speed_meters_per_second=72.0,
+            vertical_launch_angle_degrees=12.0,
+            horizontal_launch_angle_degrees=2.0,
+            total_spin_rpm=2500.0,
+            spin_axis_degrees=5.0,
+        )
+
+        result = calculate_shot(input_data)
+
+        assert result.carry_distance_meters > 200  # Should be ~226m for this shot
+        assert result.total_distance_meters > result.carry_distance_meters
+        assert result.shot_name != ""
+        assert result.shot_rank in ["S+", "S", "A", "B", "C", "D", "E"]
+
+    def test_calculate_shot_with_high_spin(self) -> None:
+        """Test calculate_shot() handles high spin shots."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+            calculate_shot,
+        )
+
+        # Wedge-like shot with high spin
+        input_data = OpenGolfCoachInput(
+            ball_speed_meters_per_second=40.0,  # ~90 mph
+            vertical_launch_angle_degrees=30.0,
+            horizontal_launch_angle_degrees=0.0,
+            total_spin_rpm=9000.0,  # High spin
+            spin_axis_degrees=0.0,
+        )
+
+        result = calculate_shot(input_data)
+
+        assert result.carry_distance_meters > 50
+        assert result.backspin_rpm > 0
+
+    def test_calculate_shot_with_slice(self) -> None:
+        """Test calculate_shot() identifies slice shots."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+            calculate_shot,
+        )
+
+        # Shot with significant sidespin (slice)
+        input_data = OpenGolfCoachInput(
+            ball_speed_meters_per_second=65.0,
+            vertical_launch_angle_degrees=11.0,
+            horizontal_launch_angle_degrees=5.0,  # Starting right
+            total_spin_rpm=3500.0,
+            spin_axis_degrees=20.0,  # Heavy slice spin axis
+        )
+
+        result = calculate_shot(input_data)
+
+        assert result.offline_distance_meters > 0  # Right of target
+
+
+class TestCalculateShotFromGC2:
+    """Tests for calculate_shot_from_gc2() convenience function."""
+
+    def test_calculate_from_gc2_shot(self) -> None:
+        """Test calculate_shot_from_gc2() processes GC2 shot data."""
+        from gc2_connect.models import GC2ShotData
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            calculate_shot_from_gc2,
+        )
+
+        gc2_shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=167.0,  # mph
+            launch_angle=10.9,
+            horizontal_launch_angle=1.5,
+            back_spin=2686.0,
+            side_spin=-250.0,
+        )
+
+        result = calculate_shot_from_gc2(gc2_shot)
+
+        # Should get valid result
+        assert result.carry_distance_yards > 200  # Driver carry
+        assert result.shot_name != ""
+        assert result.shot_rank in ["S+", "S", "A", "B", "C", "D", "E"]
+
+    def test_calculate_from_gc2_7iron(self) -> None:
+        """Test calculation for typical 7-iron shot."""
+        from gc2_connect.models import GC2ShotData
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            calculate_shot_from_gc2,
+        )
+
+        gc2_shot = GC2ShotData(
+            shot_id=2,
+            ball_speed=120.0,  # mph
+            launch_angle=18.0,
+            horizontal_launch_angle=0.0,
+            back_spin=6000.0,
+            side_spin=100.0,
+        )
+
+        result = calculate_shot_from_gc2(gc2_shot)
+
+        # 7-iron should carry 140-170 yards
+        assert 100 < result.carry_distance_yards < 200
+
+
+class TestOpenGolfCoachAvailability:
+    """Tests for library availability and graceful fallback."""
+
+    def test_opengolfcoach_is_available(self) -> None:
+        """Test that is_available() returns True when library installed."""
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import is_available
+
+        assert is_available() is True
+
+    def test_can_import_directly(self) -> None:
+        """Test direct import of opengolfcoach library works."""
+        import opengolfcoach
+
+        assert hasattr(opengolfcoach, "calculate_derived_values")
+
+
+class TestOpenGolfCoachUnavailable:
+    """Tests for behavior when OpenGolfCoach is not available."""
+
+    def test_calculate_shot_raises_when_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test calculate_shot() raises RuntimeError when library unavailable."""
+        import gc2_connect.open_range.physics.opengolfcoach_wrapper as wrapper
+
+        # Mock the availability flag to simulate library not installed
+        monkeypatch.setattr(wrapper, "_OPENGOLFCOACH_AVAILABLE", False)
+
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import (
+            OpenGolfCoachInput,
+            calculate_shot,
+        )
+
+        input_data = OpenGolfCoachInput(
+            ball_speed_meters_per_second=72.0,
+            vertical_launch_angle_degrees=12.0,
+        )
+
+        with pytest.raises(RuntimeError, match="not installed"):
+            calculate_shot(input_data)
+
+    def test_is_available_returns_false_when_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test is_available() returns False when library not installed."""
+        import gc2_connect.open_range.physics.opengolfcoach_wrapper as wrapper
+
+        # Mock the availability flag
+        monkeypatch.setattr(wrapper, "_OPENGOLFCOACH_AVAILABLE", False)
+
+        from gc2_connect.open_range.physics.opengolfcoach_wrapper import is_available
+
+        assert is_available() is False

--- a/uv.lock
+++ b/uv.lock
@@ -603,6 +603,7 @@ version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "nicegui" },
+    { name = "opengolfcoach" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyusb" },
@@ -629,6 +630,7 @@ dev = [
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "nicegui", specifier = ">=1.4.0" },
+    { name = "opengolfcoach", specifier = ">=0.1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -1195,6 +1197,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438 },
+]
+
+[[package]]
+name = "opengolfcoach"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4a/53a0cc0af9f47faa559c4e124d72dd0289e735b4a42a136a5a1fef0a85fa/opengolfcoach-0.1.0.tar.gz", hash = "sha256:bc2aeced7fab4bc56764c8a1f8c8fe7a5f1727b41be2df67afd8e2dff21a967b", size = 56610 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/d6/ab8132415d7327448bd6fe9729475d46b7550b955cd0279a2449222fe281/opengolfcoach-0.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:391c2c324f278e0559d1dbeb1f9db554cd8a4434564b099d447b301b42260bf3", size = 254552 },
+    { url = "https://files.pythonhosted.org/packages/a1/d8/46da4ba6d520fc416c078f2a1bbb1bcddc6d6ab6179fd585def48faa38de/opengolfcoach-0.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69cae6d5df7a7a1d945d588d818b383865eae54ead3dd73d8ab01b9d8d32465a", size = 265428 },
+    { url = "https://files.pythonhosted.org/packages/43/fa/e4bd9b8373972efb6cea94011fc31d1787e08574878a7264ea3f908068c2/opengolfcoach-0.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b81370744ac5fae0fc5eeca19eba33d644c63599d4641a07262577169e9a0262", size = 280072 },
+    { url = "https://files.pythonhosted.org/packages/66/15/bd505ddede799727bb72ff98ecf4d600dccf7d0139000edef64fa27251d2/opengolfcoach-0.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:552dfcbe7b9aa6296da502b1850169388ecac30d29698f01f7b596c3ec9539f9", size = 197527 },
+    { url = "https://files.pythonhosted.org/packages/23/16/4fb83785a5e4eb115a02535da8b6c3ff229399a0e91578222c1fe156495b/opengolfcoach-0.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ec29b2b00680515a2d776cb71fe3f9975bd88bdd0af10f09f74d0bd143bab0e0", size = 254552 },
+    { url = "https://files.pythonhosted.org/packages/61/e3/8480f439fbcd94e3651326d2eef0ed67a5d5730e1b5edc2d2e8e56a52dd0/opengolfcoach-0.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61db3ad51bb4232e0de6e007c0ec4863c2138fa220fd50fe60d2ae1cb5516f56", size = 265428 },
+    { url = "https://files.pythonhosted.org/packages/26/6b/62f22ae639583c3fb72a4393291ca8d4d0fce90642ff8cd4a177b008e283/opengolfcoach-0.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d7fddb072be4f3922b2f51e55a600a6d59665b0f3bf06a1b0385435940b11bc", size = 280072 },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/5ff309ece0a1a0c68abb69967b6ab146dc54f103188dd5de3e387b4ba8b4/opengolfcoach-0.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:bee5d1353c1ca09378f3d3dacc0361df1f5be8b681f87dcc0bfd3134bd537533", size = 197535 },
+    { url = "https://files.pythonhosted.org/packages/67/08/561ee2c9568660284312bc11142cc72ceccffe03c410c26122b856a9333e/opengolfcoach-0.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13341222a711c7e913f360615bb767a64d66a111405ec1359ae00edd54b1e719", size = 254320 },
+    { url = "https://files.pythonhosted.org/packages/c1/03/5186b90739dc72c0db564450eeeb7cd3d6bfc9c5e279c6dae624d8d9eaf8/opengolfcoach-0.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:677cbeb2e7a7ec17c621b22b92669bcdaf74e4bac457ff31ea6e646c2d42c372", size = 265206 },
+    { url = "https://files.pythonhosted.org/packages/44/63/dcddbf46a3989dab00448d87015e9a9c19becc054be93a4c05a9b80aa319/opengolfcoach-0.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbfd6253ae08e171597c520d362abb7ea22a919326c44b6b2d5a0ebbd13c5888", size = 279961 },
+    { url = "https://files.pythonhosted.org/packages/82/b7/bbbe3a0269f557d7d150e134d0bb013eb713a31a5e13357a7e7d2d5e8ff7/opengolfcoach-0.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:2cf9d52cd741ed6e0617509771484ad2e021229bdae1fea64b00fd0587ee7c38", size = 194115 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `opengolfcoach` package as a project dependency
- Create `opengolfcoach_wrapper.py` module with `OpenGolfCoachInput` and `OpenGolfCoachResult` dataclasses
- Implement `calculate_shot()` and `calculate_shot_from_gc2()` functions for shot physics calculations
- Add proper unit conversions between mph/m/s and meters/yards
- Add `is_available()` function to gracefully check library availability
- Handle import errors gracefully when library is not installed

## Test plan

- [x] All 20 new unit tests pass (`tests/unit/test_opengolfcoach_wrapper.py`)
- [x] All 871 existing tests pass
- [x] mypy type checking passes
- [x] ruff linting passes
- [x] ruff formatting passes

This is part of Phase 5b: OpenGolfCoach Integration (Prompt 21c).