### PR TITLE
feat: add minigames base architecture (Prompt 27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,14 @@ src/gc2_connect/
 │   ├── history.py       # Shot history manager
 │   └── export.py        # CSV export
 ├── config/              # Settings management
-└── minigames/           # (PLANNED) Minigames framework
-    ├── base.py          # BaseMinigame, GameManager
-    ├── putting_green.py # Putting practice
-    ├── target_range.py  # Target scoring
-    └── golf_darts.py    # Darts with VLA/HLA mapping
+└── minigames/           # Minigames framework (base architecture complete)
+    ├── __init__.py      # Package exports
+    ├── models.py        # GameType, GameState, GameConfig, GameScore, GameResult
+    ├── base.py          # BaseMinigame abstract class
+    ├── manager.py       # GameManager for lifecycle management
+    ├── putting_green.py # (PLANNED) Putting practice
+    ├── target_range.py  # (PLANNED) Target scoring
+    └── golf_darts.py    # (PLANNED) Darts with VLA/HLA mapping
 
 tools/
 └── mock_gspro_server.py # Testing utility
@@ -142,9 +145,7 @@ uv run python tools/mock_gspro_server.py --host 0.0.0.0 --port 921
 
 ## Upcoming Features (see plan.md/todo.md)
 
-- **OpenGolfCoach Integration** (Phase 5b): Shot classification, ranking (S+ to E), smash factor
-- **Enhanced Visuals** (Phase 5c): Procedural terrain, fog, trees, multiple camera views, minimap
-- **Minigames** (Phase 5d): Putting Green, Target Range, Golf Darts (301/501/Cricket)
+- **Minigames** (Phase 5d): Base architecture complete. Remaining: Putting Green, Target Range, Golf Darts (301/501/Cricket)
 
 ## Related Documentation
 

--- a/src/gc2_connect/minigames/__init__.py
+++ b/src/gc2_connect/minigames/__init__.py
@@ -1,0 +1,36 @@
+# ABOUTME: Minigames framework package for GC2 Connect.
+# ABOUTME: Provides base classes and models for implementing golf minigames.
+"""Minigames framework for GC2 Connect.
+
+This package provides the foundation for implementing golf minigames:
+- BaseMinigame: Abstract base class for all minigames
+- GameManager: Manages game lifecycle and shot routing
+- Models: GameType, GameState, GameConfig, GameScore, GameResult
+
+Example:
+    from gc2_connect.minigames import GameManager, GameType, GameConfig
+
+    manager = GameManager()
+    config = GameConfig(game_type=GameType.PUTTING_GREEN, player_names=["Player 1"])
+    # Set up concrete minigame implementation and start
+"""
+
+from gc2_connect.minigames.base import BaseMinigame
+from gc2_connect.minigames.manager import GameManager
+from gc2_connect.minigames.models import (
+    GameConfig,
+    GameResult,
+    GameScore,
+    GameState,
+    GameType,
+)
+
+__all__ = [
+    "BaseMinigame",
+    "GameConfig",
+    "GameManager",
+    "GameResult",
+    "GameScore",
+    "GameState",
+    "GameType",
+]

--- a/src/gc2_connect/minigames/base.py
+++ b/src/gc2_connect/minigames/base.py
@@ -1,0 +1,165 @@
+# ABOUTME: Abstract base class for all minigames.
+# ABOUTME: Defines the interface for game lifecycle, shot processing, and scoring.
+"""Abstract base class for minigames.
+
+This module provides:
+- BaseMinigame: Abstract class that all minigames must inherit from
+
+Concrete implementations must override:
+- start_game(): Initialize game state and begin play
+- process_shot(): Handle incoming shot data and return result
+- get_scores(): Return current scores for all players
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from gc2_connect.minigames.models import GameConfig, GameResult, GameScore, GameState
+
+if TYPE_CHECKING:
+    from gc2_connect.models import GC2ShotData
+
+logger = logging.getLogger(__name__)
+
+
+class BaseMinigame(ABC):
+    """Abstract base class for all minigames.
+
+    Provides common functionality for game lifecycle management,
+    player rotation, and state tracking. Concrete implementations
+    must implement the abstract methods for game-specific logic.
+
+    Example:
+        class PuttingGreen(BaseMinigame):
+            def start_game(self) -> None:
+                self._state = GameState.PLAYING
+                self._scores = [GameScore(player_name=n) for n in self.config.player_names]
+
+            def process_shot(self, shot: GC2ShotData) -> GameResult:
+                # Putting-specific logic
+                ...
+
+            def get_scores(self) -> list[GameScore]:
+                return self._scores.copy()
+    """
+
+    def __init__(self, config: GameConfig) -> None:
+        """Initialize the minigame.
+
+        Args:
+            config: Game configuration including type, players, and settings.
+        """
+        self.config = config
+        self._state = GameState.SETUP
+        self._scores: list[GameScore] = []
+        self._current_player_index = 0
+
+        logger.debug(
+            f"Initialized {config.game_type.value} with {len(config.player_names)} player(s)"
+        )
+
+    @property
+    def state(self) -> GameState:
+        """Get the current game state."""
+        return self._state
+
+    @property
+    def current_player(self) -> str:
+        """Get the name of the current player."""
+        return self.config.player_names[self._current_player_index]
+
+    @property
+    def current_player_index(self) -> int:
+        """Get the index of the current player (0-based)."""
+        return self._current_player_index
+
+    @property
+    def player_count(self) -> int:
+        """Get the number of players in the game."""
+        return len(self.config.player_names)
+
+    @abstractmethod
+    def start_game(self) -> None:
+        """Start or restart the game.
+
+        Implementations must:
+        - Set _state to GameState.PLAYING
+        - Initialize _scores for all players
+        - Reset any game-specific state
+        """
+
+    @abstractmethod
+    def process_shot(self, shot: GC2ShotData) -> GameResult:
+        """Process incoming shot data and return the result.
+
+        Implementations must:
+        - Calculate score/result based on shot data
+        - Update player scores
+        - Check for game-over conditions
+        - Return a GameResult with outcome
+
+        Args:
+            shot: The shot data from the GC2 launch monitor.
+
+        Returns:
+            GameResult containing points, message, and game_over flag.
+        """
+
+    @abstractmethod
+    def get_scores(self) -> list[GameScore]:
+        """Get current scores for all players.
+
+        Returns:
+            List of GameScore objects, one per player.
+        """
+
+    def pause_game(self) -> None:
+        """Pause the game.
+
+        Only transitions to PAUSED if currently PLAYING.
+        """
+        if self._state == GameState.PLAYING:
+            self._state = GameState.PAUSED
+            logger.debug(f"Game paused - {self.config.game_type.value}")
+
+    def resume_game(self) -> None:
+        """Resume a paused game.
+
+        Only transitions to PLAYING if currently PAUSED.
+        """
+        if self._state == GameState.PAUSED:
+            self._state = GameState.PLAYING
+            logger.debug(f"Game resumed - {self.config.game_type.value}")
+
+    def end_game(self) -> None:
+        """End the game.
+
+        Transitions to FINISHED regardless of current state.
+        """
+        self._state = GameState.FINISHED
+        logger.debug(f"Game ended - {self.config.game_type.value}")
+
+    def reset_game(self) -> None:
+        """Reset the game to initial state.
+
+        Returns to SETUP state and resets player index.
+        Does not clear scores - call start_game() to reinitialize.
+        """
+        self._state = GameState.SETUP
+        self._current_player_index = 0
+        logger.debug(f"Game reset - {self.config.game_type.value}")
+
+    def next_player(self) -> str:
+        """Advance to the next player and return their name.
+
+        Wraps around to the first player after the last.
+
+        Returns:
+            Name of the new current player.
+        """
+        self._current_player_index = (self._current_player_index + 1) % self.player_count
+        logger.debug(f"Next player: {self.current_player}")
+        return self.current_player

--- a/src/gc2_connect/minigames/manager.py
+++ b/src/gc2_connect/minigames/manager.py
@@ -1,0 +1,212 @@
+# ABOUTME: GameManager for managing minigame lifecycle and shot routing.
+# ABOUTME: Acts as a façade between the application and active minigame instances.
+"""GameManager for minigame lifecycle management.
+
+This module provides:
+- GameManager: Manages the active minigame instance and routes shots
+
+The GameManager acts as a façade between the application (ShotRouter)
+and concrete minigame implementations. It handles:
+- Setting and clearing the active game
+- Starting, pausing, resuming, and ending games
+- Routing shots to the active game
+- Providing access to scores and player state
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from gc2_connect.minigames.models import GameResult, GameScore, GameState, GameType
+
+if TYPE_CHECKING:
+    from gc2_connect.minigames.base import BaseMinigame
+    from gc2_connect.models import GC2ShotData
+
+logger = logging.getLogger(__name__)
+
+
+class GameManager:
+    """Manages minigame lifecycle and shot routing.
+
+    The GameManager is the main integration point for minigames
+    in the GC2 Connect application. It maintains a reference to
+    the active minigame and provides methods for lifecycle management
+    and shot processing.
+
+    Example:
+        manager = GameManager()
+        manager.set_game(putting_green)
+        manager.start_game()
+
+        # Shot processing
+        result = await manager.process_shot(shot_data)
+
+        # Cleanup
+        manager.end_game()
+        manager.clear_game()
+    """
+
+    def __init__(self) -> None:
+        """Initialize the GameManager with no active game."""
+        self._active_game: BaseMinigame | None = None
+        self._game_result_callback: Callable[[GameResult], Awaitable[None]] | None = None
+
+        logger.debug("GameManager initialized")
+
+    @property
+    def active_game(self) -> BaseMinigame | None:
+        """Get the currently active minigame, or None if none is set."""
+        return self._active_game
+
+    @property
+    def has_active_game(self) -> bool:
+        """Check if there is an active game in PLAYING state."""
+        return self._active_game is not None and self._active_game.state == GameState.PLAYING
+
+    @property
+    def game_type(self) -> GameType | None:
+        """Get the type of the active game, or None if no game is set."""
+        if self._active_game is None:
+            return None
+        return self._active_game.config.game_type
+
+    @property
+    def current_player(self) -> str | None:
+        """Get the current player name, or None if no game is set."""
+        if self._active_game is None:
+            return None
+        return self._active_game.current_player
+
+    def set_game(self, game: BaseMinigame) -> None:
+        """Set the active minigame.
+
+        If there is already an active game, it will be replaced.
+        The new game starts in SETUP state until start_game() is called.
+
+        Args:
+            game: The minigame instance to activate.
+        """
+        self._active_game = game
+        logger.info(f"Set active game: {game.config.game_type.value}")
+
+    def clear_game(self) -> None:
+        """Clear the active minigame.
+
+        After calling this, there will be no active game and
+        shot processing will return None.
+        """
+        if self._active_game:
+            logger.info(f"Cleared active game: {self._active_game.config.game_type.value}")
+        self._active_game = None
+
+    def start_game(self) -> None:
+        """Start the active game.
+
+        Delegates to the active game's start_game() method.
+        Does nothing if no game is set.
+        """
+        if self._active_game:
+            self._active_game.start_game()
+            logger.info(f"Started game: {self._active_game.config.game_type.value}")
+
+    def pause_game(self) -> None:
+        """Pause the active game.
+
+        Delegates to the active game's pause_game() method.
+        Does nothing if no game is set.
+        """
+        if self._active_game:
+            self._active_game.pause_game()
+
+    def resume_game(self) -> None:
+        """Resume the active game.
+
+        Delegates to the active game's resume_game() method.
+        Does nothing if no game is set.
+        """
+        if self._active_game:
+            self._active_game.resume_game()
+
+    def end_game(self) -> None:
+        """End the active game.
+
+        Delegates to the active game's end_game() method.
+        Does nothing if no game is set.
+        """
+        if self._active_game:
+            self._active_game.end_game()
+            logger.info(f"Ended game: {self._active_game.config.game_type.value}")
+
+    def reset_game(self) -> None:
+        """Reset the active game to SETUP state.
+
+        Delegates to the active game's reset_game() method.
+        Does nothing if no game is set.
+        """
+        if self._active_game:
+            self._active_game.reset_game()
+            logger.info(f"Reset game: {self._active_game.config.game_type.value}")
+
+    async def process_shot(self, shot: GC2ShotData) -> GameResult | None:
+        """Process a shot through the active minigame.
+
+        Routes the shot to the active game if one is set and PLAYING.
+        Invokes the game result callback if registered.
+
+        Args:
+            shot: The shot data from the GC2 launch monitor.
+
+        Returns:
+            GameResult from the minigame, or None if no active game
+            or game is not in PLAYING state.
+        """
+        if self._active_game is None:
+            logger.debug("No active game - shot ignored")
+            return None
+
+        if self._active_game.state != GameState.PLAYING:
+            logger.debug(f"Game not playing (state={self._active_game.state.value}) - shot ignored")
+            return None
+
+        result = self._active_game.process_shot(shot)
+        logger.debug(f"Shot processed: {result.points_earned} points, game_over={result.game_over}")
+
+        if self._game_result_callback:
+            await self._game_result_callback(result)
+
+        return result
+
+    def on_game_result(self, callback: Callable[[GameResult], Awaitable[None]]) -> None:
+        """Register a callback for game results.
+
+        The callback is invoked after each shot is processed,
+        receiving the GameResult from the minigame.
+
+        Args:
+            callback: Async function to call with game results.
+        """
+        self._game_result_callback = callback
+        logger.debug("Game result callback registered")
+
+    def get_scores(self) -> list[GameScore] | None:
+        """Get current scores from the active game.
+
+        Returns:
+            List of GameScore objects, or None if no active game.
+        """
+        if self._active_game is None:
+            return None
+        return self._active_game.get_scores()
+
+    def next_player(self) -> str | None:
+        """Advance to the next player in the active game.
+
+        Returns:
+            Name of the new current player, or None if no active game.
+        """
+        if self._active_game is None:
+            return None
+        return self._active_game.next_player()

--- a/src/gc2_connect/minigames/models.py
+++ b/src/gc2_connect/minigames/models.py
@@ -1,0 +1,122 @@
+# ABOUTME: Data models for the minigames framework.
+# ABOUTME: Defines GameType, GameState, GameConfig, GameScore, and GameResult.
+"""Data models for the minigames framework.
+
+This module provides:
+- GameType: Enum of available minigame types
+- GameState: Enum of game states (setup, playing, paused, finished)
+- GameConfig: Configuration for starting a minigame
+- GameScore: Player score tracking
+- GameResult: Result of processing a shot
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated, Any
+
+from pydantic import BaseModel, Field
+
+
+class GameType(str, Enum):
+    """Types of minigames available.
+
+    Each minigame type has unique mechanics and scoring:
+    - PUTTING_GREEN: Practice putting with stimpmeter physics
+    - TARGET_RANGE: Hit targets at various distances for points
+    - GOLF_DARTS: Map shot VLA/HLA to dartboard positions
+    """
+
+    PUTTING_GREEN = "putting_green"
+    TARGET_RANGE = "target_range"
+    GOLF_DARTS = "golf_darts"
+
+
+class GameState(str, Enum):
+    """Current state of a minigame.
+
+    State transitions:
+    - SETUP → PLAYING (start_game)
+    - PLAYING → PAUSED (pause_game)
+    - PAUSED → PLAYING (resume_game)
+    - PLAYING/PAUSED → FINISHED (end_game or game_over)
+    - Any → SETUP (reset_game)
+    """
+
+    SETUP = "setup"
+    PLAYING = "playing"
+    PAUSED = "paused"
+    FINISHED = "finished"
+
+
+class GameConfig(BaseModel):
+    """Configuration for starting a minigame.
+
+    Provides common settings for all minigames including player setup
+    and optional shot limits. Specific minigames may extend this with
+    game-specific configuration.
+
+    Example:
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["Alice", "Bob"],
+            max_shots=21,  # 7 rounds of 3 darts
+        )
+    """
+
+    game_type: Annotated[GameType, Field(description="Type of minigame to play")]
+    player_names: Annotated[list[str], Field(description="Names of players in order of play")] = [
+        "Player 1"
+    ]
+    max_shots: Annotated[
+        int | None,
+        Field(description="Maximum total shots before game ends (None = unlimited)"),
+    ] = None
+
+
+class GameScore(BaseModel):
+    """Score tracking for a player in a minigame.
+
+    Tracks basic metrics (shots and score) plus game-specific data
+    in the extra_data field.
+
+    Example:
+        score = GameScore(
+            player_name="Alice",
+            shots_taken=9,
+            score=180,
+            extra_data={"triples": 3, "doubles": 2},
+        )
+    """
+
+    player_name: Annotated[str, Field(description="Name of the player")]
+    shots_taken: Annotated[int, Field(description="Number of shots taken")] = 0
+    score: Annotated[int, Field(description="Current score (can be negative)")] = 0
+    extra_data: Annotated[
+        dict[str, Any], Field(default_factory=dict, description="Game-specific additional data")
+    ]
+
+
+class GameResult(BaseModel):
+    """Result of processing a shot in a minigame.
+
+    Returned by BaseMinigame.process_shot() to communicate the outcome
+    of a shot back to the game manager and UI.
+
+    Example:
+        result = GameResult(
+            points_earned=60,
+            message="Triple 20!",
+            game_over=False,
+            extra_data={"ring": "triple", "number": 20},
+        )
+    """
+
+    points_earned: Annotated[
+        int, Field(description="Points earned (can be negative for busts)")
+    ] = 0
+    message: Annotated[str, Field(description="Human-readable result message")] = ""
+    game_over: Annotated[bool, Field(description="Whether the game has ended")] = False
+    extra_data: Annotated[
+        dict[str, Any], Field(default_factory=dict, description="Game-specific additional data")
+    ]

--- a/src/gc2_connect/services/shot_router.py
+++ b/src/gc2_connect/services/shot_router.py
@@ -1,10 +1,10 @@
-# ABOUTME: Routes shot data to GSPro or Open Range based on current mode.
+# ABOUTME: Routes shot data to GSPro, Open Range, or Minigames based on current mode.
 # ABOUTME: Handles mode switching and destination management.
 """Shot routing service for GC2 Connect.
 
 This module provides:
-- AppMode: Enum for application modes (GSPRO, OPEN_RANGE)
-- ShotRouter: Routes shots between GSPro and Open Range
+- AppMode: Enum for application modes (GSPRO, OPEN_RANGE, MINIGAME)
+- ShotRouter: Routes shots between GSPro, Open Range, and Minigames
 
 The ShotRouter acts as a central dispatcher for shot data from the GC2
 launch monitor, directing shots to the appropriate destination based
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from gc2_connect.gspro.client import GSProClient
+    from gc2_connect.minigames.manager import GameManager
+    from gc2_connect.minigames.models import GameResult
     from gc2_connect.models import GC2ShotData
     from gc2_connect.open_range.engine import OpenRangeEngine
     from gc2_connect.open_range.models import ShotResult
@@ -33,18 +35,20 @@ class AppMode(str, Enum):
     Determines where shot data is routed:
     - GSPRO: Shots are sent to GSPro golf simulator
     - OPEN_RANGE: Shots are simulated locally in Open Range
+    - MINIGAME: Shots are processed by the active minigame
     """
 
     GSPRO = "gspro"
     OPEN_RANGE = "open_range"
+    MINIGAME = "minigame"
 
 
 class ShotRouter:
-    """Routes shots between GSPro and Open Range modes.
+    """Routes shots between GSPro, Open Range, and Minigame modes.
 
     The router maintains the current application mode and directs
     shot data to the appropriate destination. It supports:
-    - Mode switching between GSPro and Open Range
+    - Mode switching between GSPro, Open Range, and Minigame
     - Callbacks for mode changes and shot results
     - Graceful handling of missing clients/engines
 
@@ -52,6 +56,7 @@ class ShotRouter:
         router = ShotRouter()
         router.set_gspro_client(gspro_client)
         router.set_open_range_engine(open_range_engine)
+        router.set_game_manager(game_manager)
         router.on_mode_change(handle_mode_change)
         router.on_shot_result(handle_open_range_result)
 
@@ -63,8 +68,10 @@ class ShotRouter:
         self._mode = AppMode.GSPRO
         self._gspro_client: GSProClient | None = None
         self._open_range_engine: OpenRangeEngine | None = None
+        self._game_manager: GameManager | None = None
         self._mode_change_callback: Callable[[AppMode], Awaitable[None]] | None = None
         self._shot_result_callback: Callable[[ShotResult], Awaitable[None]] | None = None
+        self._game_result_callback: Callable[[GameResult], Awaitable[None]] | None = None
 
     @property
     def mode(self) -> AppMode:
@@ -109,6 +116,14 @@ class ShotRouter:
         """
         self._open_range_engine = engine
 
+    def set_game_manager(self, manager: GameManager) -> None:
+        """Set the game manager for minigame shot routing.
+
+        Args:
+            manager: The GameManager instance.
+        """
+        self._game_manager = manager
+
     def on_mode_change(self, callback: Callable[[AppMode], Awaitable[None]]) -> None:
         """Register a callback for mode changes.
 
@@ -131,11 +146,23 @@ class ShotRouter:
         """
         self._shot_result_callback = callback
 
+    def on_game_result(self, callback: Callable[[GameResult], Awaitable[None]]) -> None:
+        """Register a callback for minigame results.
+
+        The callback is invoked after a shot is processed in a minigame,
+        receiving the GameResult with points and outcome.
+
+        Args:
+            callback: Async function to call with game results.
+        """
+        self._game_result_callback = callback
+
     async def route_shot(self, shot: GC2ShotData) -> None:
         """Route a shot to the appropriate destination.
 
         In GSPRO mode, the shot is sent to the GSPro client.
         In OPEN_RANGE mode, the shot is simulated locally.
+        In MINIGAME mode, the shot is processed by the active minigame.
 
         Args:
             shot: The GC2 shot data to route.
@@ -145,8 +172,10 @@ class ShotRouter:
         """
         if self._mode == AppMode.GSPRO:
             await self._route_to_gspro(shot)
-        else:
+        elif self._mode == AppMode.OPEN_RANGE:
             await self._route_to_open_range(shot)
+        else:
+            await self._route_to_minigame(shot)
 
     async def _route_to_gspro(self, shot: GC2ShotData) -> None:
         """Send shot to GSPro.
@@ -180,3 +209,21 @@ class ShotRouter:
 
         if self._shot_result_callback:
             await self._shot_result_callback(result)
+
+    async def _route_to_minigame(self, shot: GC2ShotData) -> None:
+        """Process shot in active minigame.
+
+        Args:
+            shot: The GC2 shot data to process.
+
+        Raises:
+            RuntimeError: If game manager is not configured.
+        """
+        if not self._game_manager:
+            raise RuntimeError("Game manager not configured")
+
+        logger.debug(f"Routing shot {shot.shot_id} to Minigame")
+        result = await self._game_manager.process_shot(shot)
+
+        if result is not None and self._game_result_callback:
+            await self._game_result_callback(result)

--- a/tests/unit/test_minigames/__init__.py
+++ b/tests/unit/test_minigames/__init__.py
@@ -1,0 +1,3 @@
+# ABOUTME: Test package for minigames framework.
+# ABOUTME: Contains unit tests for minigame models, base class, and manager.
+"""Unit tests for the minigames framework."""

--- a/tests/unit/test_minigames/test_base.py
+++ b/tests/unit/test_minigames/test_base.py
@@ -1,0 +1,395 @@
+# ABOUTME: Unit tests for BaseMinigame abstract class.
+# ABOUTME: Tests game lifecycle, state transitions, and player management.
+"""Unit tests for BaseMinigame abstract class."""
+
+from __future__ import annotations
+
+from gc2_connect.minigames.base import BaseMinigame
+from gc2_connect.minigames.models import (
+    GameConfig,
+    GameResult,
+    GameScore,
+    GameState,
+    GameType,
+)
+from gc2_connect.models import GC2ShotData
+
+
+class MockMinigame(BaseMinigame):
+    """Mock minigame implementation for testing."""
+
+    def __init__(self, config: GameConfig) -> None:
+        super().__init__(config)
+        self._shots_received: list[GC2ShotData] = []
+
+    def start_game(self) -> None:
+        """Start the game."""
+        self._state = GameState.PLAYING
+        self._shots_received = []
+        self._scores = [GameScore(player_name=name) for name in self.config.player_names]
+
+    def process_shot(self, shot: GC2ShotData) -> GameResult:
+        """Process a shot and return result."""
+        self._shots_received.append(shot)
+
+        # Simple scoring: 10 points per shot
+        current_score = self._get_current_player_score()
+        if current_score:
+            current_score.shots_taken += 1
+            current_score.score += 10
+
+        # Check for max shots
+        total_shots = sum(s.shots_taken for s in self._scores)
+        game_over = self.config.max_shots is not None and total_shots >= self.config.max_shots
+
+        if game_over:
+            self._state = GameState.FINISHED
+
+        return GameResult(
+            points_earned=10,
+            message=f"Shot processed for {self.current_player}",
+            game_over=game_over,
+        )
+
+    def get_scores(self) -> list[GameScore]:
+        """Get current scores."""
+        return self._scores.copy()
+
+    def _get_current_player_score(self) -> GameScore | None:
+        """Get the score object for current player."""
+        for score in self._scores:
+            if score.player_name == self.current_player:
+                return score
+        return None
+
+
+class TestBaseMinigameInitialization:
+    """Tests for BaseMinigame initialization."""
+
+    def test_initial_state_is_setup(self) -> None:
+        """Test that initial state is SETUP."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+        assert game.state == GameState.SETUP
+
+    def test_config_stored(self) -> None:
+        """Test that config is stored correctly."""
+        config = GameConfig(
+            game_type=GameType.TARGET_RANGE,
+            player_names=["Alice", "Bob"],
+        )
+        game = MockMinigame(config)
+        assert game.config == config
+        assert game.config.player_names == ["Alice", "Bob"]
+
+    def test_current_player_initial(self) -> None:
+        """Test that current player starts at first player."""
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["First", "Second", "Third"],
+        )
+        game = MockMinigame(config)
+        assert game.current_player == "First"
+
+    def test_current_player_index_initial(self) -> None:
+        """Test that current player index starts at 0."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+        assert game.current_player_index == 0
+
+
+class TestBaseMinigameStateTransitions:
+    """Tests for BaseMinigame state transitions."""
+
+    def test_start_game_changes_state_to_playing(self) -> None:
+        """Test that start_game changes state to PLAYING."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        assert game.state == GameState.SETUP
+        game.start_game()
+        assert game.state == GameState.PLAYING
+
+    def test_pause_game_from_playing(self) -> None:
+        """Test that pause_game changes state to PAUSED from PLAYING."""
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        game.start_game()
+        assert game.state == GameState.PLAYING
+
+        game.pause_game()
+        assert game.state == GameState.PAUSED
+
+    def test_pause_game_only_from_playing(self) -> None:
+        """Test that pause_game only works from PLAYING state."""
+        config = GameConfig(game_type=GameType.GOLF_DARTS)
+        game = MockMinigame(config)
+
+        # Try to pause from SETUP - should not change state
+        game.pause_game()
+        assert game.state == GameState.SETUP
+
+    def test_resume_game_from_paused(self) -> None:
+        """Test that resume_game changes state from PAUSED to PLAYING."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        game.start_game()
+        game.pause_game()
+        assert game.state == GameState.PAUSED
+
+        game.resume_game()
+        assert game.state == GameState.PLAYING
+
+    def test_resume_game_only_from_paused(self) -> None:
+        """Test that resume_game only works from PAUSED state."""
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        game.start_game()
+        assert game.state == GameState.PLAYING
+
+        # Try to resume from PLAYING - should not change state
+        game.resume_game()
+        assert game.state == GameState.PLAYING
+
+    def test_end_game_changes_state_to_finished(self) -> None:
+        """Test that end_game changes state to FINISHED."""
+        config = GameConfig(game_type=GameType.GOLF_DARTS)
+        game = MockMinigame(config)
+
+        game.start_game()
+        game.end_game()
+        assert game.state == GameState.FINISHED
+
+    def test_end_game_from_paused(self) -> None:
+        """Test that end_game works from PAUSED state."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        game.start_game()
+        game.pause_game()
+        game.end_game()
+        assert game.state == GameState.FINISHED
+
+    def test_reset_game_returns_to_setup(self) -> None:
+        """Test that reset_game returns state to SETUP."""
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        game.start_game()
+        game.reset_game()
+        assert game.state == GameState.SETUP
+
+    def test_reset_game_clears_player_index(self) -> None:
+        """Test that reset_game resets player index to 0."""
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["Alice", "Bob", "Charlie"],
+        )
+        game = MockMinigame(config)
+
+        game.start_game()
+        game.next_player()
+        game.next_player()
+        assert game.current_player == "Charlie"
+
+        game.reset_game()
+        assert game.current_player == "Alice"
+        assert game.current_player_index == 0
+
+
+class TestBaseMinigamePlayerManagement:
+    """Tests for BaseMinigame player management."""
+
+    def test_next_player_advances(self) -> None:
+        """Test that next_player advances to next player."""
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["Alice", "Bob"],
+        )
+        game = MockMinigame(config)
+
+        assert game.current_player == "Alice"
+        result = game.next_player()
+        assert result == "Bob"
+        assert game.current_player == "Bob"
+
+    def test_next_player_wraps_around(self) -> None:
+        """Test that next_player wraps around to first player."""
+        config = GameConfig(
+            game_type=GameType.TARGET_RANGE,
+            player_names=["One", "Two", "Three"],
+        )
+        game = MockMinigame(config)
+
+        assert game.current_player == "One"
+        game.next_player()
+        assert game.current_player == "Two"
+        game.next_player()
+        assert game.current_player == "Three"
+        game.next_player()
+        assert game.current_player == "One"  # Wrapped around
+
+    def test_single_player_next_stays_same(self) -> None:
+        """Test that next_player with single player stays the same."""
+        config = GameConfig(
+            game_type=GameType.PUTTING_GREEN,
+            player_names=["Solo"],
+        )
+        game = MockMinigame(config)
+
+        assert game.current_player == "Solo"
+        game.next_player()
+        assert game.current_player == "Solo"
+
+    def test_player_count_property(self) -> None:
+        """Test player_count property."""
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["A", "B", "C", "D"],
+        )
+        game = MockMinigame(config)
+        assert game.player_count == 4
+
+
+class TestBaseMinigameShotProcessing:
+    """Tests for BaseMinigame shot processing."""
+
+    def test_process_shot_returns_result(self) -> None:
+        """Test that process_shot returns a GameResult."""
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+        game.start_game()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=12.0,
+            horizontal_launch_angle=1.0,
+            back_spin=3000.0,
+            side_spin=500.0,
+        )
+        result = game.process_shot(shot)
+
+        assert isinstance(result, GameResult)
+        assert result.points_earned == 10
+
+    def test_process_shot_updates_score(self) -> None:
+        """Test that process_shot updates player score."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+        game.start_game()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=15.0,
+            launch_angle=5.0,
+            horizontal_launch_angle=0.0,
+            back_spin=500.0,
+            side_spin=0.0,
+        )
+        game.process_shot(shot)
+
+        scores = game.get_scores()
+        assert len(scores) == 1
+        assert scores[0].shots_taken == 1
+        assert scores[0].score == 10
+
+    def test_process_shot_with_max_shots(self) -> None:
+        """Test that game ends when max_shots reached."""
+        config = GameConfig(
+            game_type=GameType.TARGET_RANGE,
+            max_shots=3,
+        )
+        game = MockMinigame(config)
+        game.start_game()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=10.0,
+            horizontal_launch_angle=0.0,
+            back_spin=2500.0,
+            side_spin=0.0,
+        )
+
+        # First two shots - not game over
+        result1 = game.process_shot(shot)
+        assert not result1.game_over
+        assert game.state == GameState.PLAYING
+
+        result2 = game.process_shot(shot)
+        assert not result2.game_over
+
+        # Third shot - game over
+        result3 = game.process_shot(shot)
+        assert result3.game_over
+        assert game.state == GameState.FINISHED
+
+
+class TestBaseMinigameScoring:
+    """Tests for BaseMinigame scoring."""
+
+    def test_get_scores_returns_all_players(self) -> None:
+        """Test that get_scores returns scores for all players."""
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["Alice", "Bob", "Charlie"],
+        )
+        game = MockMinigame(config)
+        game.start_game()
+
+        scores = game.get_scores()
+        assert len(scores) == 3
+        names = [s.player_name for s in scores]
+        assert "Alice" in names
+        assert "Bob" in names
+        assert "Charlie" in names
+
+    def test_get_scores_returns_copy(self) -> None:
+        """Test that get_scores returns a copy, not original."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+        game.start_game()
+
+        scores1 = game.get_scores()
+        scores2 = game.get_scores()
+
+        assert scores1 is not scores2
+
+    def test_scores_track_per_player(self) -> None:
+        """Test that scores are tracked per player."""
+        config = GameConfig(
+            game_type=GameType.TARGET_RANGE,
+            player_names=["Alice", "Bob"],
+        )
+        game = MockMinigame(config)
+        game.start_game()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=10.0,
+            horizontal_launch_angle=0.0,
+            back_spin=2500.0,
+            side_spin=0.0,
+        )
+
+        # Alice shoots twice
+        game.process_shot(shot)
+        game.process_shot(shot)
+        game.next_player()
+
+        # Bob shoots once
+        game.process_shot(shot)
+
+        scores = game.get_scores()
+        alice_score = next(s for s in scores if s.player_name == "Alice")
+        bob_score = next(s for s in scores if s.player_name == "Bob")
+
+        assert alice_score.shots_taken == 2
+        assert alice_score.score == 20
+        assert bob_score.shots_taken == 1
+        assert bob_score.score == 10

--- a/tests/unit/test_minigames/test_manager.py
+++ b/tests/unit/test_minigames/test_manager.py
@@ -1,0 +1,371 @@
+# ABOUTME: Unit tests for GameManager class.
+# ABOUTME: Tests game lifecycle management and shot routing to minigames.
+"""Unit tests for GameManager class."""
+
+from __future__ import annotations
+
+import pytest
+
+from gc2_connect.minigames.base import BaseMinigame
+from gc2_connect.minigames.manager import GameManager
+from gc2_connect.minigames.models import (
+    GameConfig,
+    GameResult,
+    GameScore,
+    GameState,
+    GameType,
+)
+from gc2_connect.models import GC2ShotData
+
+
+class MockMinigame(BaseMinigame):
+    """Mock minigame for testing GameManager."""
+
+    def __init__(self, config: GameConfig) -> None:
+        super().__init__(config)
+        self.shots_received: list[GC2ShotData] = []
+        self._scores: list[GameScore] = []
+
+    def start_game(self) -> None:
+        """Start the game."""
+        self._state = GameState.PLAYING
+        self.shots_received = []
+        self._scores = [GameScore(player_name=name) for name in self.config.player_names]
+
+    def process_shot(self, shot: GC2ShotData) -> GameResult:
+        """Process a shot."""
+        self.shots_received.append(shot)
+        return GameResult(
+            points_earned=10,
+            message="Test shot processed",
+        )
+
+    def get_scores(self) -> list[GameScore]:
+        """Get scores."""
+        return self._scores.copy()
+
+
+class TestGameManagerInitialization:
+    """Tests for GameManager initialization."""
+
+    def test_initial_state(self) -> None:
+        """Test GameManager initial state."""
+        manager = GameManager()
+        assert manager.active_game is None
+        assert manager.has_active_game is False
+
+    def test_game_type_none_initially(self) -> None:
+        """Test that game_type is None when no game is set."""
+        manager = GameManager()
+        assert manager.game_type is None
+
+
+class TestGameManagerGameLifecycle:
+    """Tests for GameManager game lifecycle."""
+
+    def test_set_game(self) -> None:
+        """Test setting an active game."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        assert manager.active_game is game
+        assert manager.game_type == GameType.PUTTING_GREEN
+
+    def test_start_game(self) -> None:
+        """Test starting a game through manager."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+
+        assert game.state == GameState.PLAYING
+        assert manager.has_active_game is True
+
+    def test_start_game_no_game_set(self) -> None:
+        """Test that start_game does nothing when no game is set."""
+        manager = GameManager()
+        manager.start_game()  # Should not raise
+        assert manager.has_active_game is False
+
+    def test_pause_game(self) -> None:
+        """Test pausing a game through manager."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.GOLF_DARTS)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        manager.pause_game()
+
+        assert game.state == GameState.PAUSED
+        assert manager.has_active_game is False  # Paused game not "active"
+
+    def test_resume_game(self) -> None:
+        """Test resuming a game through manager."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        manager.pause_game()
+        manager.resume_game()
+
+        assert game.state == GameState.PLAYING
+        assert manager.has_active_game is True
+
+    def test_end_game(self) -> None:
+        """Test ending a game through manager."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        manager.end_game()
+
+        assert game.state == GameState.FINISHED
+        assert manager.has_active_game is False
+
+    def test_reset_game(self) -> None:
+        """Test resetting a game through manager."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.GOLF_DARTS)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        manager.reset_game()
+
+        assert game.state == GameState.SETUP
+        assert manager.has_active_game is False
+
+    def test_clear_game(self) -> None:
+        """Test clearing the active game."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.clear_game()
+
+        assert manager.active_game is None
+        assert manager.game_type is None
+
+
+class TestGameManagerShotProcessing:
+    """Tests for GameManager shot processing."""
+
+    @pytest.mark.asyncio
+    async def test_process_shot_routes_to_game(self) -> None:
+        """Test that process_shot routes to active game."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=12.0,
+            horizontal_launch_angle=0.0,
+            back_spin=3000.0,
+            side_spin=0.0,
+        )
+        result = await manager.process_shot(shot)
+
+        assert result is not None
+        assert result.points_earned == 10
+        assert len(game.shots_received) == 1
+        assert game.shots_received[0] == shot
+
+    @pytest.mark.asyncio
+    async def test_process_shot_no_game_returns_none(self) -> None:
+        """Test that process_shot returns None when no game set."""
+        manager = GameManager()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=12.0,
+            horizontal_launch_angle=0.0,
+            back_spin=3000.0,
+            side_spin=0.0,
+        )
+        result = await manager.process_shot(shot)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_process_shot_game_not_playing_returns_none(self) -> None:
+        """Test that process_shot returns None when game not playing."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.GOLF_DARTS)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        # Don't start the game
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=12.0,
+            horizontal_launch_angle=0.0,
+            back_spin=3000.0,
+            side_spin=0.0,
+        )
+        result = await manager.process_shot(shot)
+
+        assert result is None
+        assert len(game.shots_received) == 0
+
+    @pytest.mark.asyncio
+    async def test_process_shot_game_paused_returns_none(self) -> None:
+        """Test that process_shot returns None when game is paused."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        manager.pause_game()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=15.0,
+            launch_angle=5.0,
+            horizontal_launch_angle=0.0,
+            back_spin=500.0,
+            side_spin=0.0,
+        )
+        result = await manager.process_shot(shot)
+
+        assert result is None
+
+
+class TestGameManagerCallbacks:
+    """Tests for GameManager callbacks."""
+
+    @pytest.mark.asyncio
+    async def test_game_result_callback_invoked(self) -> None:
+        """Test that game result callback is invoked."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        received_results: list[GameResult] = []
+
+        async def callback(result: GameResult) -> None:
+            received_results.append(result)
+
+        manager.on_game_result(callback)
+        manager.set_game(game)
+        manager.start_game()
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=12.0,
+            horizontal_launch_angle=0.0,
+            back_spin=3000.0,
+            side_spin=0.0,
+        )
+        await manager.process_shot(shot)
+
+        assert len(received_results) == 1
+        assert received_results[0].points_earned == 10
+
+    @pytest.mark.asyncio
+    async def test_callback_not_invoked_when_no_game(self) -> None:
+        """Test that callback is not invoked when no active game."""
+        manager = GameManager()
+
+        received_results: list[GameResult] = []
+
+        async def callback(result: GameResult) -> None:
+            received_results.append(result)
+
+        manager.on_game_result(callback)
+
+        shot = GC2ShotData(
+            shot_id=1,
+            ball_speed=100.0,
+            launch_angle=12.0,
+            horizontal_launch_angle=0.0,
+            back_spin=3000.0,
+            side_spin=0.0,
+        )
+        await manager.process_shot(shot)
+
+        assert len(received_results) == 0
+
+
+class TestGameManagerScoreAccess:
+    """Tests for GameManager score access."""
+
+    def test_get_scores_returns_game_scores(self) -> None:
+        """Test that get_scores returns scores from active game."""
+        manager = GameManager()
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["Alice", "Bob"],
+        )
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+
+        scores = manager.get_scores()
+        assert scores is not None
+        assert len(scores) == 2
+
+    def test_get_scores_no_game_returns_none(self) -> None:
+        """Test that get_scores returns None when no game set."""
+        manager = GameManager()
+        scores = manager.get_scores()
+        assert scores is None
+
+    def test_current_player_from_game(self) -> None:
+        """Test that current_player returns from active game."""
+        manager = GameManager()
+        config = GameConfig(
+            game_type=GameType.PUTTING_GREEN,
+            player_names=["First", "Second"],
+        )
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        assert manager.current_player == "First"
+
+    def test_current_player_no_game_returns_none(self) -> None:
+        """Test that current_player returns None when no game set."""
+        manager = GameManager()
+        assert manager.current_player is None
+
+    def test_next_player_from_game(self) -> None:
+        """Test that next_player advances player in active game."""
+        manager = GameManager()
+        config = GameConfig(
+            game_type=GameType.TARGET_RANGE,
+            player_names=["Alice", "Bob"],
+        )
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        assert manager.current_player == "Alice"
+
+        result = manager.next_player()
+        assert result == "Bob"
+        assert manager.current_player == "Bob"
+
+    def test_next_player_no_game_returns_none(self) -> None:
+        """Test that next_player returns None when no game set."""
+        manager = GameManager()
+        result = manager.next_player()
+        assert result is None

--- a/tests/unit/test_minigames/test_models.py
+++ b/tests/unit/test_minigames/test_models.py
@@ -1,0 +1,267 @@
+# ABOUTME: Unit tests for minigame data models.
+# ABOUTME: Tests GameType, GameState, GameConfig, GameScore, and GameResult.
+"""Unit tests for minigame models."""
+
+from __future__ import annotations
+
+from gc2_connect.minigames.models import (
+    GameConfig,
+    GameResult,
+    GameScore,
+    GameState,
+    GameType,
+)
+
+
+class TestGameType:
+    """Tests for GameType enum."""
+
+    def test_putting_green_value(self) -> None:
+        """Test PUTTING_GREEN enum value."""
+        assert GameType.PUTTING_GREEN == "putting_green"
+        assert GameType.PUTTING_GREEN.value == "putting_green"
+
+    def test_target_range_value(self) -> None:
+        """Test TARGET_RANGE enum value."""
+        assert GameType.TARGET_RANGE == "target_range"
+        assert GameType.TARGET_RANGE.value == "target_range"
+
+    def test_golf_darts_value(self) -> None:
+        """Test GOLF_DARTS enum value."""
+        assert GameType.GOLF_DARTS == "golf_darts"
+        assert GameType.GOLF_DARTS.value == "golf_darts"
+
+    def test_all_types_unique(self) -> None:
+        """Test that all game types have unique values."""
+        values = [t.value for t in GameType]
+        assert len(values) == len(set(values))
+
+    def test_string_comparison(self) -> None:
+        """Test that GameType can be compared to strings."""
+        assert GameType.PUTTING_GREEN == "putting_green"
+        assert GameType.TARGET_RANGE == "target_range"
+        assert GameType.GOLF_DARTS == "golf_darts"
+
+
+class TestGameState:
+    """Tests for GameState enum."""
+
+    def test_setup_state(self) -> None:
+        """Test SETUP state value."""
+        assert GameState.SETUP == "setup"
+        assert GameState.SETUP.value == "setup"
+
+    def test_playing_state(self) -> None:
+        """Test PLAYING state value."""
+        assert GameState.PLAYING == "playing"
+        assert GameState.PLAYING.value == "playing"
+
+    def test_paused_state(self) -> None:
+        """Test PAUSED state value."""
+        assert GameState.PAUSED == "paused"
+        assert GameState.PAUSED.value == "paused"
+
+    def test_finished_state(self) -> None:
+        """Test FINISHED state value."""
+        assert GameState.FINISHED == "finished"
+        assert GameState.FINISHED.value == "finished"
+
+    def test_all_states_unique(self) -> None:
+        """Test that all game states have unique values."""
+        values = [s.value for s in GameState]
+        assert len(values) == len(set(values))
+
+
+class TestGameConfig:
+    """Tests for GameConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test GameConfig with default values."""
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        assert config.game_type == GameType.PUTTING_GREEN
+        assert config.player_names == ["Player 1"]
+        assert config.max_shots is None
+
+    def test_custom_player_names(self) -> None:
+        """Test GameConfig with custom player names."""
+        config = GameConfig(
+            game_type=GameType.TARGET_RANGE,
+            player_names=["Alice", "Bob", "Charlie"],
+        )
+        assert config.player_names == ["Alice", "Bob", "Charlie"]
+
+    def test_max_shots(self) -> None:
+        """Test GameConfig with max_shots set."""
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            max_shots=21,  # 7 rounds of 3 darts
+        )
+        assert config.max_shots == 21
+
+    def test_single_player(self) -> None:
+        """Test GameConfig with single player."""
+        config = GameConfig(
+            game_type=GameType.PUTTING_GREEN,
+            player_names=["Solo Player"],
+        )
+        assert len(config.player_names) == 1
+        assert config.player_names[0] == "Solo Player"
+
+    def test_multi_player(self) -> None:
+        """Test GameConfig with multiple players."""
+        config = GameConfig(
+            game_type=GameType.GOLF_DARTS,
+            player_names=["Player 1", "Player 2", "Player 3", "Player 4"],
+        )
+        assert len(config.player_names) == 4
+
+    def test_serialization(self) -> None:
+        """Test that GameConfig can be serialized to dict."""
+        config = GameConfig(
+            game_type=GameType.TARGET_RANGE,
+            player_names=["Test"],
+            max_shots=10,
+        )
+        data = config.model_dump()
+        assert data["game_type"] == "target_range"
+        assert data["player_names"] == ["Test"]
+        assert data["max_shots"] == 10
+
+    def test_deserialization(self) -> None:
+        """Test that GameConfig can be deserialized from dict."""
+        data = {
+            "game_type": "putting_green",
+            "player_names": ["Alice", "Bob"],
+            "max_shots": 20,
+        }
+        config = GameConfig.model_validate(data)
+        assert config.game_type == GameType.PUTTING_GREEN
+        assert config.player_names == ["Alice", "Bob"]
+        assert config.max_shots == 20
+
+
+class TestGameScore:
+    """Tests for GameScore model."""
+
+    def test_default_values(self) -> None:
+        """Test GameScore with default values."""
+        score = GameScore(player_name="Test Player")
+        assert score.player_name == "Test Player"
+        assert score.shots_taken == 0
+        assert score.score == 0
+        assert score.extra_data == {}
+
+    def test_with_shots_and_score(self) -> None:
+        """Test GameScore with shots and score set."""
+        score = GameScore(
+            player_name="Alice",
+            shots_taken=5,
+            score=150,
+        )
+        assert score.shots_taken == 5
+        assert score.score == 150
+
+    def test_extra_data(self) -> None:
+        """Test GameScore with extra game-specific data."""
+        score = GameScore(
+            player_name="Bob",
+            shots_taken=3,
+            score=60,
+            extra_data={
+                "triples": 2,
+                "doubles": 1,
+                "bullseyes": 0,
+            },
+        )
+        assert score.extra_data["triples"] == 2
+        assert score.extra_data["doubles"] == 1
+        assert score.extra_data["bullseyes"] == 0
+
+    def test_negative_score_allowed(self) -> None:
+        """Test that negative scores are allowed (for some games)."""
+        score = GameScore(
+            player_name="Charlie",
+            score=-10,
+        )
+        assert score.score == -10
+
+    def test_serialization(self) -> None:
+        """Test that GameScore can be serialized."""
+        score = GameScore(
+            player_name="Test",
+            shots_taken=10,
+            score=100,
+            extra_data={"level": 5},
+        )
+        data = score.model_dump()
+        assert data["player_name"] == "Test"
+        assert data["shots_taken"] == 10
+        assert data["score"] == 100
+        assert data["extra_data"]["level"] == 5
+
+
+class TestGameResult:
+    """Tests for GameResult model."""
+
+    def test_default_values(self) -> None:
+        """Test GameResult with default values."""
+        result = GameResult()
+        assert result.points_earned == 0
+        assert result.message == ""
+        assert result.game_over is False
+        assert result.extra_data == {}
+
+    def test_with_points_and_message(self) -> None:
+        """Test GameResult with points and message."""
+        result = GameResult(
+            points_earned=20,
+            message="Triple 20!",
+        )
+        assert result.points_earned == 20
+        assert result.message == "Triple 20!"
+
+    def test_game_over_flag(self) -> None:
+        """Test GameResult with game_over flag."""
+        result = GameResult(
+            points_earned=50,
+            message="BULLSEYE! Game Over!",
+            game_over=True,
+        )
+        assert result.game_over is True
+
+    def test_extra_data(self) -> None:
+        """Test GameResult with extra data."""
+        result = GameResult(
+            points_earned=60,
+            message="Triple 20!",
+            extra_data={
+                "ring": "triple",
+                "number": 20,
+                "multiplier": 3,
+            },
+        )
+        assert result.extra_data["ring"] == "triple"
+        assert result.extra_data["number"] == 20
+        assert result.extra_data["multiplier"] == 3
+
+    def test_negative_points(self) -> None:
+        """Test GameResult with negative points (bust in 301/501)."""
+        result = GameResult(
+            points_earned=-50,
+            message="BUST! Score reset.",
+        )
+        assert result.points_earned == -50
+
+    def test_serialization(self) -> None:
+        """Test that GameResult can be serialized."""
+        result = GameResult(
+            points_earned=25,
+            message="Inner bull!",
+            game_over=False,
+            extra_data={"ring": "outer_bull"},
+        )
+        data = result.model_dump()
+        assert data["points_earned"] == 25
+        assert data["message"] == "Inner bull!"
+        assert data["game_over"] is False
+        assert data["extra_data"]["ring"] == "outer_bull"

--- a/tests/unit/test_shot_router.py
+++ b/tests/unit/test_shot_router.py
@@ -8,6 +8,15 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from gc2_connect.minigames.base import BaseMinigame
+from gc2_connect.minigames.manager import GameManager
+from gc2_connect.minigames.models import (
+    GameConfig,
+    GameResult,
+    GameScore,
+    GameState,
+    GameType,
+)
 from gc2_connect.models import GC2ShotData
 from gc2_connect.services.shot_router import AppMode, ShotRouter
 
@@ -32,6 +41,28 @@ def sample_shot() -> GC2ShotData:
     )
 
 
+class MockMinigame(BaseMinigame):
+    """Mock minigame for testing ShotRouter integration."""
+
+    def __init__(self, config: GameConfig) -> None:
+        super().__init__(config)
+        self.shots_received: list[GC2ShotData] = []
+
+    def start_game(self) -> None:
+        """Start the game."""
+        self._state = GameState.PLAYING
+        self._scores = [GameScore(player_name=name) for name in self.config.player_names]
+
+    def process_shot(self, shot: GC2ShotData) -> GameResult:
+        """Process a shot."""
+        self.shots_received.append(shot)
+        return GameResult(points_earned=10, message="Test shot")
+
+    def get_scores(self) -> list[GameScore]:
+        """Get scores."""
+        return self._scores.copy()
+
+
 class TestAppModeEnum:
     """Tests for AppMode enum."""
 
@@ -42,6 +73,10 @@ class TestAppModeEnum:
     def test_open_range_mode_value(self) -> None:
         """Test OPEN_RANGE mode has correct value."""
         assert AppMode.OPEN_RANGE.value == "open_range"
+
+    def test_minigame_mode_value(self) -> None:
+        """Test MINIGAME mode has correct value."""
+        assert AppMode.MINIGAME.value == "minigame"
 
     def test_mode_is_string_enum(self) -> None:
         """Test modes can be used as strings."""
@@ -63,6 +98,10 @@ class TestShotRouterInitialization:
     def test_open_range_engine_initially_none(self, shot_router: ShotRouter) -> None:
         """Test that Open Range engine is initially not set."""
         assert shot_router._open_range_engine is None
+
+    def test_game_manager_initially_none(self, shot_router: ShotRouter) -> None:
+        """Test that game manager is initially not set."""
+        assert shot_router._game_manager is None
 
     def test_callbacks_initially_none(self, shot_router: ShotRouter) -> None:
         """Test that callbacks are initially not set."""
@@ -301,3 +340,129 @@ class TestShotCallbacks:
         await shot_router.route_shot(sample_shot)
 
         mock_engine.simulate_shot.assert_called_once()
+
+
+class TestMinigameIntegration:
+    """Tests for minigame mode integration."""
+
+    def test_set_game_manager(self, shot_router: ShotRouter) -> None:
+        """Test setting game manager."""
+        manager = GameManager()
+        shot_router.set_game_manager(manager)
+        assert shot_router._game_manager is manager
+
+    @pytest.mark.asyncio
+    async def test_set_mode_to_minigame(self, shot_router: ShotRouter) -> None:
+        """Test switching mode to Minigame."""
+        await shot_router.set_mode(AppMode.MINIGAME)
+        assert shot_router.mode == AppMode.MINIGAME
+
+    @pytest.mark.asyncio
+    async def test_route_shot_minigame_mode_routes_to_manager(
+        self, shot_router: ShotRouter, sample_shot: GC2ShotData
+    ) -> None:
+        """Test that shots are routed to game manager in MINIGAME mode."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.TARGET_RANGE)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        shot_router.set_game_manager(manager)
+
+        await shot_router.set_mode(AppMode.MINIGAME)
+        await shot_router.route_shot(sample_shot)
+
+        assert len(game.shots_received) == 1
+        assert game.shots_received[0] == sample_shot
+
+    @pytest.mark.asyncio
+    async def test_route_shot_minigame_no_manager_raises(
+        self, shot_router: ShotRouter, sample_shot: GC2ShotData
+    ) -> None:
+        """Test that routing to minigame without manager raises error."""
+        await shot_router.set_mode(AppMode.MINIGAME)
+        with pytest.raises(RuntimeError, match="Game manager not configured"):
+            await shot_router.route_shot(sample_shot)
+
+    @pytest.mark.asyncio
+    async def test_route_shot_minigame_invokes_game_result_callback(
+        self, shot_router: ShotRouter, sample_shot: GC2ShotData
+    ) -> None:
+        """Test that game result callback is invoked in MINIGAME mode."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.GOLF_DARTS)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        shot_router.set_game_manager(manager)
+
+        callback = AsyncMock()
+        shot_router.on_game_result(callback)
+
+        await shot_router.set_mode(AppMode.MINIGAME)
+        await shot_router.route_shot(sample_shot)
+
+        callback.assert_called_once()
+        result = callback.call_args[0][0]
+        assert isinstance(result, GameResult)
+        assert result.points_earned == 10
+
+    @pytest.mark.asyncio
+    async def test_route_shot_minigame_no_active_game_no_callback(
+        self, shot_router: ShotRouter, sample_shot: GC2ShotData
+    ) -> None:
+        """Test that callback is not invoked when no active game."""
+        manager = GameManager()
+        # No game set
+        shot_router.set_game_manager(manager)
+
+        callback = AsyncMock()
+        shot_router.on_game_result(callback)
+
+        await shot_router.set_mode(AppMode.MINIGAME)
+        await shot_router.route_shot(sample_shot)
+
+        callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_minigame_works_without_gspro_or_open_range(
+        self, shot_router: ShotRouter, sample_shot: GC2ShotData
+    ) -> None:
+        """Test that minigame mode works without other engines configured."""
+        manager = GameManager()
+        config = GameConfig(game_type=GameType.PUTTING_GREEN)
+        game = MockMinigame(config)
+
+        manager.set_game(game)
+        manager.start_game()
+        shot_router.set_game_manager(manager)
+
+        # No GSPro client or Open Range engine configured
+        await shot_router.set_mode(AppMode.MINIGAME)
+        await shot_router.route_shot(sample_shot)
+
+        assert len(game.shots_received) == 1
+
+    def test_on_game_result_registers_callback(self, shot_router: ShotRouter) -> None:
+        """Test registering game result callback."""
+        callback = AsyncMock()
+        shot_router.on_game_result(callback)
+        assert shot_router._game_result_callback is callback
+
+    @pytest.mark.asyncio
+    async def test_mode_transitions_between_all_modes(self, shot_router: ShotRouter) -> None:
+        """Test that mode transitions work between all modes."""
+        # GSPro -> Open Range -> Minigame -> GSPro
+        callback = AsyncMock()
+        shot_router.on_mode_change(callback)
+
+        await shot_router.set_mode(AppMode.OPEN_RANGE)
+        await shot_router.set_mode(AppMode.MINIGAME)
+        await shot_router.set_mode(AppMode.GSPRO)
+
+        assert callback.call_count == 3
+        callback.assert_any_call(AppMode.OPEN_RANGE)
+        callback.assert_any_call(AppMode.MINIGAME)
+        callback.assert_any_call(AppMode.GSPRO)

--- a/todo.md
+++ b/todo.md
@@ -105,9 +105,18 @@ Target Release: v1.1.0 (with Open Range)
 
 ---
 
-## Phase 5d: Minigames Framework (PLANNED)
+## Phase 5d: Minigames Framework (IN PROGRESS)
 
-- [ ] **Prompt 27**: Minigames Base Architecture
+- [x] **Prompt 27**: Minigames Base Architecture
+  - [x] Create GameType enum (PUTTING_GREEN, TARGET_RANGE, GOLF_DARTS)
+  - [x] Create GameState enum (SETUP, PLAYING, PAUSED, FINISHED)
+  - [x] Create GameConfig, GameScore, GameResult models
+  - [x] Create BaseMinigame abstract base class
+  - [x] Create GameManager for game lifecycle management
+  - [x] Add MINIGAME mode to AppMode enum
+  - [x] Update ShotRouter to route shots to minigames
+  - [x] Write tests in tests/unit/test_minigames/
+
 - [ ] **Prompt 28**: Putting Green Minigame
 - [ ] **Prompt 29**: Target Range Minigame
 - [ ] **Prompt 30**: Golf Darts Minigame


### PR DESCRIPTION
## Summary
- Add foundational framework for golf minigames (Phase 5d)
- Create `GameType` enum with PUTTING_GREEN, TARGET_RANGE, GOLF_DARTS
- Create `GameState` enum for lifecycle management
- Create `BaseMinigame` abstract class for game implementations
- Create `GameManager` for game lifecycle and shot routing
- Update `ShotRouter` to support MINIGAME mode

## Changes

### New Files
- `src/gc2_connect/minigames/models.py` - Data models (GameType, GameState, GameConfig, GameScore, GameResult)
- `src/gc2_connect/minigames/base.py` - BaseMinigame abstract class
- `src/gc2_connect/minigames/manager.py` - GameManager for lifecycle management
- `tests/unit/test_minigames/` - 73 unit tests for minigames framework

### Modified Files
- `src/gc2_connect/services/shot_router.py` - Added MINIGAME mode and GameManager integration
- `tests/unit/test_shot_router.py` - 10 new tests for minigame routing
- `todo.md` - Mark Prompt 27 as complete

## Test plan
- [x] All 1117 tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff check)
- [x] Formatting passes (ruff format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #31