### PR TITLE
Migrate GSPro client to asyncio with infinite reconnect

### DIFF
--- a/docs/GSPRO_TCP_PROTOCOL.md
+++ b/docs/GSPRO_TCP_PROTOCOL.md
@@ -1,0 +1,390 @@
+# GSPro Open Connect API — TCP Protocol (v1)
+
+Wire-level specification of the connector ↔ GSPro integration for **GSPro v1.x**. GSPro is a Windows golf-simulator package; it exposes a TCP "Open Connect API" so third-party launch monitors can feed shot data into a round.
+
+This document is implementation-language-agnostic. It describes the protocol from the client (launch-monitor connector) perspective.
+
+> Source: this document was derived from two pieces of evidence:
+> 1. `docs/GsProApi.cs` — the OpenSkyPlus2 / GSPro4OSP reference connector source, which is the closest thing to an official wire spec.
+> 2. The working `src/gc2_connect/gspro/client.py` integration in this repository.
+>
+> Earlier revisions of this document mixed in details from a different launch-monitor's connector (different inbound discriminator, different sign conventions, no `IsHeartBeat`, split ball/club messages). Those details did **not** apply to GSPro v1.x and have been removed. If you find newer/different behavior in production GSPro, prefer reality over this document.
+
+## 1. Transport
+
+| Property | Value |
+|---|---|
+| Protocol | Plain TCP (no TLS) |
+| Default host/port | `127.0.0.1:921` (localhost) |
+| Role | GSPro listens, the connector dials |
+| Framing | JSON objects, `\n`-terminated |
+
+**Socket setup (client-side):**
+
+- **`TCP_NODELAY`**: enable. GSPro relies on prompt delivery of small JSON messages; Nagle batching introduces visible lag.
+- **`SO_KEEPALIVE`**: enable, ~30 s idle. GSPro does not send application-level heartbeats *to* the client, so OS-level keepalive is the only reliable way to detect a half-open connection (e.g. GSPro process killed without a FIN).
+  - macOS: `setsockopt(IPPROTO_TCP, TCP_KEEPALIVE, 30)`.
+  - Linux: `TCP_KEEPIDLE=30`, `TCP_KEEPINTVL=10`, `TCP_KEEPCNT=3` (~60 s to detect a dead peer).
+- **Read pattern**: a long-running reader task that consumes whatever GSPro sends. Do not synchronously `recv` after each send expecting an ack — see §6.
+
+## 2. Message framing
+
+JSON objects are carried over the TCP stream.
+
+### Outbound (client → GSPro)
+
+Every outbound message is one JSON object followed by a single newline byte (`\n`, `0x0A`):
+
+```text
+{"DeviceID":"GC2 Connect","APIversion":"1",...}\n
+```
+
+The newline is required. The reference implementation (`docs/GsProApi.cs`) appends `+ "\n"` to every write (shot data, heartbeat, status update, command). Without it, two messages sent in quick succession can land in the same TCP segment and the second is dropped by GSPro's line-oriented reader. Pretty-printed JSON is fine as long as exactly one `\n` follows the closing `}`.
+
+### Inbound (GSPro → client)
+
+GSPro is **mostly** line-oriented but not strictly so:
+
+- Most messages are one JSON object terminated by `\n` or `\r\n`. The reference implementation splits inbound bytes on `'\n'` and `'\r'`.
+- During the initial handshake, GSPro may send the bare string `GSPro ready` (no JSON envelope). Treat this as equivalent to a `Code:202` match-start signal (see §4.2).
+- Defensive parsing: accumulate inbound bytes, try `JSON.parse` on each line; if a line fails to parse and contains `GSPro ready`, treat it as the bare handshake; otherwise log and skip. A balanced-brace `raw_decode` parser is a stronger fallback if GSPro ever batches.
+
+The reference client reads up to 4096 bytes at a time and processes whatever lines are complete, retaining any trailing partial line for the next read.
+
+## 3. Reconnection policy
+
+GSPro can disappear mid-session (process restart, computer sleep, user close). Recommended client behavior:
+
+- Initial backoff: 5 seconds.
+- Backoff doubles on each failed attempt, capped at 60 seconds.
+- **Retry indefinitely.** The reference (`GsProApi.cs` `ConnectLoopAsync`) treats `MaxRetries < 0` as unbounded and that is the default. The user cancels manually via "Disconnect".
+- On reconnect, the client resets its `ShotNumber` to 0. GSPro tracks shots independently and accepts the reset.
+
+The reconnect task runs concurrently with everything else; it must not block I/O paths.
+
+## 4. Inbound messages (GSPro → client)
+
+After the initial handshake, all post-handshake inbound messages are JSON objects discriminated by a top-level integer `Code` field:
+
+```jsonc
+{ "Code": <int>, "Message": "<string>", "Player": { /* optional */ } }
+```
+
+Known codes:
+
+### 4.1 `Code: 200` — Generic OK
+
+Acknowledgement of a shot data message. Informational; payload typically `{"Code":200,"Message":"OK"}` or similar. Acks are **not** flow control — if you miss one, just keep sending. GSPro does not retry or NACK.
+
+### 4.2 `Code: 202` — GSPro ready / match started
+
+```json
+{"Code": 202, "Message": "GSPro ready"}
+```
+
+Sent when GSPro is ready to receive shot data (player teed off, returned from menu, or session start). May also arrive as the **bare string** `GSPro ready` (no JSON envelope) during initial handshake — treat it identically.
+
+**Required action:** arm the launch monitor (enable ball detection), start heartbeats (§6.2).
+
+### 4.3 `Code: 201` — Player information
+
+```json
+{
+  "Code": 201,
+  "Message": "Player info",
+  "Player": {
+    "Handed": "RH",
+    "Club": "I7",
+    "DistanceToTarget": 145.2,
+    "Surface": "Fairway"
+  }
+}
+```
+
+Sent when the active player, their selected club, or distance-to-target changes. After delivering this message GSPro is effectively re-armed (similar in effect to `202`).
+
+`Player` field semantics:
+
+- `Handed` — `"RH"` (right-handed), `"LH"` (left-handed). Other values fall back to right-handed.
+- `Club` — two-letter club code (see §4.3.1).
+- `DistanceToTarget` — number, meters. Used by client to decide putting/short-chip mode.
+- `Surface` — optional string (e.g. `"Fairway"`, `"Tee"`, `"Rough"`, `"Green"`).
+
+The reference debounces a burst of 201s within ~2 s to avoid thrashing on rapid updates.
+
+#### 4.3.1 Club code dictionary
+
+| Code | Description |
+|---|---|
+| `DR` | Driver |
+| `W2`–`W7` | 2- through 7-wood |
+| `H2`–`H7` | 2- through 7-hybrid |
+| `I1`–`I9` | 1- through 9-iron |
+| `PW` | Pitching wedge |
+| `AW` | Approach (gap) wedge |
+| `GW` | Gap wedge |
+| `SW` | Sand wedge |
+| `LW` | Lob wedge |
+| `PT` | Putter |
+
+Unknown codes should be passed through to the UI as "unmapped" rather than rejected — new clubs may appear in future GSPro versions.
+
+### 4.4 `Code: 203` — Round/match ended
+
+```json
+{"Code": 203, "Message": "GSPro round ended"}
+```
+
+The current round/match is over. Stop heartbeats; the launch monitor can stay connected for the next round.
+
+### 4.5 `Code: 5xx` — Error
+
+GSPro signalled an error processing a prior message. Log and continue; do not assume the connection is broken.
+
+### 4.6 Other codes
+
+Treat any unrecognized `Code` value as informational and log it. The protocol may grow.
+
+## 5. Outbound messages (client → GSPro)
+
+There is exactly **one outbound JSON schema** (`GsProRequest`). All variations — shot, heartbeat, status — share the same envelope; what differs is the `ShotDataOptions` flags and whether `BallData` / `ClubData` carry real measurements.
+
+### 5.1 Full schema
+
+```jsonc
+{
+  "DeviceID":   "GC2 Connect",
+  "APIversion": "1",
+  "Units":      "Yards",
+  "ShotNumber": 14,
+  "BallData": {
+    "Speed":         145.5,
+    "SpinAxis":       -3.5,
+    "TotalSpin":    2800.0,
+    "BackSpin":     2790.0,
+    "SideSpin":     -170.0,
+    "HLA":             1.2,
+    "VLA":            12.5,
+    "CarryDistance":   0.0
+  },
+  "ClubData": {
+    "Speed":                102.0,
+    "AngleOfAttack":         -1.5,
+    "FaceToTarget":           0.8,
+    "Lie":                    0.0,
+    "Loft":                  13.2,
+    "Path":                   1.1,
+    "SpeedAtImpact":        102.0,
+    "VerticalFaceImpact":     2.0,
+    "HorizontalFaceImpact":  -1.0,
+    "ClosureRate":            0.0,
+    "DynamicLoft":           13.2,
+    "SmashFactor":            1.43
+  },
+  "ShotDataOptions": {
+    "ContainsBallData":          true,
+    "ContainsClubData":          true,
+    "LaunchMonitorIsReady":      true,
+    "LaunchMonitorBallDetected": true,
+    "IsHeartBeat":               false
+  }
+}
+```
+
+### 5.2 Top-level fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `DeviceID` | string | Free-form identifier shown in GSPro logs. Choose something stable per integration. |
+| `APIversion` | string | `"1"`. Only one version exists. |
+| `Units` | string | `"Yards"`. GSPro normalizes regardless of choice, but `"Yards"` is conventional. |
+| `ShotNumber` | integer | Monotonic per TCP session. Incremented once per real shot. On reconnect, reset to 0. |
+| `BallData` | object | Optional. Present iff `ContainsBallData=true` *or* you want to send placeholder values. Reference includes an empty object even when not used. |
+| `ClubData` | object | Optional. Same convention as `BallData`. |
+| `ShotDataOptions` | object | Required. See §5.5. |
+
+### 5.3 `BallData` fields
+
+All values numeric. Coordinate conventions: HLA positive = right of target, VLA positive = up. Spin axis/side spin signs match GSPro's native convention (no negation needed) when sourced from the GC2's native field names.
+
+| Field | Unit | Notes |
+|---|---|---|
+| `Speed` | mph | Ball speed at separation. Convert from m/s with `× 2.23694` if your device reports m/s. |
+| `SpinAxis` | degrees | Positive = right-axis tilt (fade for RH). |
+| `TotalSpin` | RPM | |
+| `BackSpin` | RPM | |
+| `SideSpin` | RPM | Positive = right (fade for RH). |
+| `HLA` | degrees | Horizontal launch angle. |
+| `VLA` | degrees | Vertical launch angle. |
+| `CarryDistance` | yards | Optional; `0` if not estimated client-side. |
+
+### 5.4 `ClubData` fields
+
+All numeric. Fields you don't measure should be `0.0` — GSPro treats `0` as "missing" and back-fills from its own physics model.
+
+| Field | Unit | Notes |
+|---|---|---|
+| `Speed` | mph | Club head speed. |
+| `AngleOfAttack` | degrees | Positive = up. |
+| `FaceToTarget` | degrees | Positive = open (right of target for RH). |
+| `Lie` | degrees | Dynamic lie angle. |
+| `Loft` | degrees | Dynamic loft at impact. |
+| `Path` | degrees | Positive = in-to-out (right of target for RH). |
+| `SpeedAtImpact` | mph | Usually equal to `Speed`. |
+| `VerticalFaceImpact` | mm | Sole-to-crown impact position. |
+| `HorizontalFaceImpact` | mm | Heel-to-toe impact position. |
+| `ClosureRate` | deg/s | |
+| `DynamicLoft` | degrees | Optional; often equals `Loft`. |
+| `SmashFactor` | unitless | Optional. |
+
+### 5.5 `ShotDataOptions` flags
+
+| Flag | Type | Meaning |
+|---|---|---|
+| `ContainsBallData` | bool | `true` if `BallData` carries a real measurement. |
+| `ContainsClubData` | bool | `true` if `ClubData` carries real measurements. |
+| `LaunchMonitorIsReady` | bool | "I'm armed and ready to detect a shot." |
+| `LaunchMonitorBallDetected` | bool | "There's a ball in front of me right now." |
+| `IsHeartBeat` | bool | `true` for periodic heartbeat pings; `false` for shots and event-driven status updates. |
+
+`LaunchMonitorIsReady` should typically reflect **both** hardware readiness (e.g. green light on the launch monitor) **and** GSPro match state (saw a `Code:202`). Reporting `IsReady=true` while no match is active confuses GSPro.
+
+## 6. Message patterns
+
+The reference connector emits three distinct outbound shapes.
+
+### 6.1 Shot data (new swing)
+
+Emitted once per swing, after the device has produced ball *and* club metrics (or ball-only if no HMT). **Increment `ShotNumber` before sending.**
+
+```jsonc
+{
+  "DeviceID": "GC2 Connect",
+  "APIversion": "1",
+  "Units": "Yards",
+  "ShotNumber": 14,
+  "BallData": { /* §5.3 */ },
+  "ClubData": { /* §5.4, zeros if unavailable */ },
+  "ShotDataOptions": {
+    "ContainsBallData": true,
+    "ContainsClubData": true,
+    "LaunchMonitorIsReady": true,
+    "LaunchMonitorBallDetected": false,
+    "IsHeartBeat": false
+  }
+}
+```
+
+A single combined ball+club message is the standard. The GC2 protocol delivers ball and club in two USB packets within ~1 s of each other; the connector buffers ball, waits briefly for club, then emits one combined GSPro message. (Earlier protocol descriptions claimed separate ball-only and club-only emits were required — that does not match the reference and is not necessary.)
+
+Expected ack: `{"Code":200,"Message":"..."}`. Informational; do not block waiting for it.
+
+### 6.2 Heartbeat (periodic)
+
+Emitted every ~6 s while a match is active. Confirms the connector is still alive and reports current readiness.
+
+```jsonc
+{
+  "DeviceID": "GC2 Connect",
+  "APIversion": "1",
+  "Units": "Yards",
+  "ShotDataOptions": {
+    "ContainsBallData": false,
+    "ContainsClubData": false,
+    "LaunchMonitorIsReady": true,
+    "LaunchMonitorBallDetected": false,
+    "IsHeartBeat": true
+  }
+}
+```
+
+- Do **not** increment `ShotNumber` for heartbeats.
+- `ShotNumber` may be omitted entirely (the reference omits it).
+- No `BallData` / `ClubData` needed.
+- GSPro does not respond to heartbeats — do not wait for an ack.
+
+### 6.3 Status update (event-driven)
+
+Emitted when launch-monitor readiness or ball-detection state changes (separate from the periodic heartbeat).
+
+```jsonc
+{
+  "DeviceID": "GC2 Connect",
+  "APIversion": "1",
+  "Units": "Yards",
+  "ShotDataOptions": {
+    "ContainsBallData": false,
+    "ContainsClubData": false,
+    "LaunchMonitorIsReady": true,
+    "LaunchMonitorBallDetected": true,
+    "IsHeartBeat": false
+  }
+}
+```
+
+- Same skeleton as heartbeat but `IsHeartBeat=false`.
+- GSPro does not respond. Do not wait.
+- Use to inform GSPro the user has placed a ball, or the device has finished its post-shot cooldown.
+
+### 6.4 Shutdown handshake
+
+When the connector is disconnecting cleanly:
+
+1. Stop the heartbeat timer.
+2. Send one final status with `LaunchMonitorIsReady=false` and `IsHeartBeat=true`.
+3. Wait ~250 ms for GSPro to process.
+4. Close the socket.
+
+This tells GSPro the launch monitor is going offline gracefully rather than disappearing.
+
+## 7. Session lifecycle
+
+Typical flow:
+
+1. Connector dials `127.0.0.1:921`. Sets `TCP_NODELAY` and `SO_KEEPALIVE`.
+2. Connector sends an initial heartbeat (`IsReady=false`, `IsHeartBeat=true`) to register.
+3. Both sides idle until GSPro sends `GSPro ready` (bare or `Code:202`) or `Code:201` with player info.
+4. Connector arms the launch monitor, starts the periodic heartbeat (§6.2), and may send a status update (§6.3) to confirm.
+5. Player swings → launch monitor produces shot metrics → connector emits §6.1.
+6. GSPro replies with a `Code:200` ack (informational), eventually followed by another `Code:201` for the next shot's player/club/distance context.
+7. Steps 4–6 repeat for each shot until `Code:203` (round ended) or the user disconnects.
+
+`ShotNumber` continues to climb for the duration of the TCP connection. On reconnect, the client resets `ShotNumber` to 0 — GSPro tracks shots independently and accepts the reset.
+
+## 8. Error handling
+
+| Condition | Handling |
+|---|---|
+| TCP connect fails | Apply backoff (§3) and retry. Surface state to UI. |
+| TCP read returns 0 bytes | Peer closed. Disconnect locally and start reconnect. |
+| Socket error during read or write | Same — disconnect and reconnect. |
+| Read silence | Normal between events. SO_KEEPALIVE handles dead-peer detection. |
+| Inbound JSON parse fails | If line contains `GSPro ready`, handle as `Code:202`. Otherwise log and skip the line. |
+| Inbound message with unknown `Code` | Log and ignore. |
+| Outbound write fails | Close socket, start reconnect. The shot/heartbeat is lost — GSPro does not retry. |
+| GSPro sends `Code:5xx` | Log; connection is still healthy. |
+
+Acks are **informational**, not flow control. Missing an ack is not a failure condition.
+
+## 9. Implementing a new client — checklist
+
+Minimum viable client:
+
+1. Open TCP socket to `127.0.0.1:921` (configurable host/port). Set `TCP_NODELAY` and `SO_KEEPALIVE`.
+2. Send initial heartbeat (`§6.2` shape with `IsReady=false`) to register.
+3. Start a reader task: read line-by-line (or bytes with `raw_decode` fallback); dispatch by `Code`. Handle the bare `GSPro ready` handshake string.
+4. On `Code:202` (or bare `GSPro ready`): arm the device, start the 6-second heartbeat timer, transition `IsReady` reporting to track real hardware state.
+5. On `Code:201`: update internal player state (handedness, club, distance-to-target).
+6. On `Code:203`: stop heartbeats; stay connected.
+7. Maintain a `ShotNumber` integer. Increment **only** on emitting a shot data message (§6.1). Reset to 0 on reconnect.
+8. On shot: emit §6.1 with one combined ball+club JSON, terminated by `\n`. Do not block on the ack.
+9. On readiness/ball-detection state change: emit §6.3.
+10. Implement the reconnect policy (§3) on any socket error.
+11. On clean shutdown: emit final §6.4 status, sleep ~250 ms, close socket.
+
+Things you can skip:
+
+- `APIversion` switching — only `"1"` exists.
+- Buffering acks — they have no functional effect.
+- TLS / authentication — not part of the protocol.
+- Sign flips on `SpinAxis` / `SideSpin` — GSPro's convention matches the GC2's native fields directly. If you see fade/draw inverted in GSPro, fix it in your device adapter, not in the GSPro outbound layer.

--- a/docs/superpowers/plans/2026-05-11-gspro-client-async-migration.md
+++ b/docs/superpowers/plans/2026-05-11-gspro-client-async-migration.md
@@ -1,0 +1,1616 @@
+# GSPro Client Async Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `GSProClient` to native `asyncio` streams with newline framing, `SO_KEEPALIVE`, and infinite reconnect — without changing the GSPro wire format.
+
+**Architecture:** Replace `socket.socket` + sync I/O + `run_in_executor` wrappers with `asyncio.open_connection` (StreamReader/StreamWriter). Reader loop becomes `await reader.read()` with a balanced-brace fallback. All `send_*` methods become `async`. `ReconnectionManager` gains `max_retries: int | None = None` to support infinite retries; the GSPro manager uses 5s→60s capped backoff and retries forever.
+
+**Tech Stack:** Python 3.10+, `asyncio.StreamReader`/`StreamWriter`, `asyncio.open_connection`, `pytest-asyncio` (already configured `asyncio_mode = "auto"`), `unittest.mock.AsyncMock`, `MockGSProServer` from `tests/simulators/gspro/`.
+
+**Source spec:** `docs/superpowers/specs/2026-05-11-gspro-client-async-migration-design.md`. **Wire protocol reference:** `docs/GSPRO_TCP_PROTOCOL.md`.
+
+---
+
+## Background: what is GSProClient
+
+`src/gc2_connect/gspro/client.py` is the TCP client that talks to the GSPro golf simulator on port 921. It does three things:
+
+1. **Outbound**: sends one of three message shapes — shot data (`§6.1` of `GSPRO_TCP_PROTOCOL.md`), periodic heartbeat (`§6.2`), event-driven status update (`§6.3`).
+2. **Inbound**: a long-running reader task that consumes GSPro's responses (discriminated by integer `Code`: 201 player info, 202 match started, 203 round ended, 5xx error). The handshake may include a bare non-JSON `GSPro ready` string.
+3. **Connection lifecycle**: connect (with a registration heartbeat), keep alive while a match is running, disconnect cleanly with a final `LaunchMonitorIsReady=false` heartbeat.
+
+Today it's all sync sockets wrapped in `run_in_executor`. We're moving to native asyncio streams.
+
+## File map
+
+| Path | Role | Touched in tasks |
+|---|---|---|
+| `src/gc2_connect/utils/reconnect.py` | Generic exponential-backoff reconnect helper | Task 1 |
+| `src/gc2_connect/gspro/client.py` | TCP client for GSPro | Task 2 |
+| `src/gc2_connect/services/connection_manager.py` | Wraps `GSProClient`, persists shot number, owns the GSPro `ReconnectionManager` | Tasks 2, 3 |
+| `src/gc2_connect/services/shot_router.py` | Routes shots to GSPro or other targets | Task 2 |
+| `src/gc2_connect/ui/app.py` | NiceGUI UI; calls `send_status` from a status handler | Task 2 |
+| `tests/conftest.py` | `gspro_client` fixture | Task 2 |
+| `tests/unit/test_gspro_heartbeat.py` | Heartbeat / match-state unit tests | Task 2 |
+| `tests/unit/test_reconnect_manager.py` *(may exist; if not, create)* | `ReconnectionManager` tests | Task 1 |
+| `tests/integration/test_gspro_client_async.py` *(create)* | Async I/O behavior of `GSProClient` against `MockGSProServer` | Task 2 |
+| `tests/integration/test_gspro_reconnect.py` *(create)* | Reconnect-policy integration tests | Task 3 |
+
+---
+
+## Task 1: `ReconnectionManager` supports infinite retries
+
+**Why first:** independent of everything else. Smallest blast radius. The new `GSProConnectionManager` defaults in Task 3 depend on this.
+
+**Files:**
+- Modify: `src/gc2_connect/utils/reconnect.py:41-92, 126-189`
+- Test: `tests/unit/test_reconnect_manager.py` (create if it doesn't exist; otherwise add to existing)
+
+**Reference reading:**
+- `src/gc2_connect/utils/reconnect.py` — full file is short (~200 lines).
+
+- [ ] **Step 1: Check whether the test file exists**
+
+Run:
+```bash
+ls tests/unit/test_reconnect_manager.py 2>/dev/null || echo "MISSING"
+```
+
+If `MISSING`, create the file with this header:
+```python
+# ABOUTME: Unit tests for ReconnectionManager exponential-backoff reconnect helper.
+# ABOUTME: Covers retry-count semantics, infinite-retry mode, cancellation, and delay calculation.
+"""Unit tests for ReconnectionManager."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gc2_connect.utils.reconnect import ReconnectionManager, ReconnectionState
+```
+
+- [ ] **Step 2: Write the failing test for infinite retries**
+
+Append to `tests/unit/test_reconnect_manager.py`:
+
+```python
+class TestInfiniteRetries:
+    """Test that max_retries=None means infinite retries."""
+
+    @pytest.mark.asyncio
+    async def test_infinite_retries_keeps_attempting_past_default_cap(self) -> None:
+        """When max_retries=None the loop should keep attempting beyond any normal cap."""
+        mgr = ReconnectionManager(max_retries=None, base_delay=0.0, max_delay=0.0)
+        attempts = 0
+
+        def fail_then_succeed() -> bool:
+            nonlocal attempts
+            attempts += 1
+            return attempts >= 50  # success on the 50th attempt
+
+        result = await mgr.attempt_reconnect(fail_then_succeed)
+        assert result is True
+        assert attempts == 50
+        assert mgr.state == ReconnectionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_infinite_retries_stops_on_cancel(self) -> None:
+        """When max_retries=None the loop should stop when cancel() is called."""
+        mgr = ReconnectionManager(max_retries=None, base_delay=0.0, max_delay=0.0)
+        attempts = 0
+
+        def fail_and_cancel_after_3() -> bool:
+            nonlocal attempts
+            attempts += 1
+            if attempts >= 3:
+                mgr.cancel()
+            return False
+
+        result = await mgr.attempt_reconnect(fail_and_cancel_after_3)
+        assert result is False
+        assert mgr.state == ReconnectionState.DISCONNECTED
+        # Should have stopped soon after cancel
+        assert 3 <= attempts <= 5
+
+    @pytest.mark.asyncio
+    async def test_finite_retries_still_exits_at_max(self) -> None:
+        """Confirm we did not regress the bounded-retry path: max_retries=3 still exits."""
+        mgr = ReconnectionManager(max_retries=3, base_delay=0.0, max_delay=0.0)
+
+        def always_fail() -> bool:
+            return False
+
+        result = await mgr.attempt_reconnect(always_fail)
+        assert result is False
+        assert mgr.state == ReconnectionState.FAILED
+        assert mgr.retry_count == 3
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run:
+```bash
+uv run pytest tests/unit/test_reconnect_manager.py::TestInfiniteRetries -v
+```
+
+Expected: the two new infinite-retry tests fail. The most likely failure is a `TypeError` constructing `ReconnectionManager(max_retries=None, ...)` because the current signature is `max_retries: int = 5`. (The third test, `test_finite_retries_still_exits_at_max`, should already pass — it's a regression guard.)
+
+- [ ] **Step 4: Update `ReconnectionManager.__init__` typing**
+
+Modify `src/gc2_connect/utils/reconnect.py:41-56`:
+
+```python
+def __init__(
+    self,
+    max_retries: int | None = 5,
+    base_delay: float = 1.0,
+    max_delay: float = 16.0,
+) -> None:
+    """Initialize the reconnection manager.
+
+    Args:
+        max_retries: Maximum number of reconnection attempts. ``None`` means
+            retry forever until ``cancel()`` is called.
+        base_delay: Initial delay between retries in seconds
+        max_delay: Maximum delay between retries in seconds
+    """
+    self.max_retries = max_retries
+    self.base_delay = base_delay
+    self.max_delay = max_delay
+
+    self._state = ReconnectionState.DISCONNECTED
+    self._retry_count = 0
+    self._cancelled = False
+
+    # Callbacks
+    self._state_callbacks: list[Callable[[ReconnectionState], None]] = []
+    self._attempt_callbacks: list[Callable[[int, float], None]] = []
+```
+
+- [ ] **Step 5: Update the `attempt_reconnect` loop condition**
+
+Modify `src/gc2_connect/utils/reconnect.py:144-189` (the body of `attempt_reconnect`):
+
+```python
+self._cancelled = False
+self._retry_count = 0
+self._set_state(ReconnectionState.CONNECTING)
+
+def _should_continue(attempt: int) -> bool:
+    if self._cancelled:
+        return False
+    if self.max_retries is None:
+        return True
+    return attempt < self.max_retries
+
+attempt = 0
+while _should_continue(attempt):
+    try:
+        result = connect_fn()
+        if asyncio.iscoroutine(result):
+            success = await result
+        else:
+            success = result
+
+        if success:
+            self._set_state(ReconnectionState.CONNECTED)
+            logger.info("Reconnection successful")
+            return True
+
+    except Exception as e:
+        logger.warning(f"Connection attempt {attempt + 1} failed: {e}")
+
+    attempt += 1
+    self._retry_count = attempt
+
+    if _should_continue(attempt):
+        delay = self.get_delay_for_attempt(attempt - 1)
+        self._set_state(ReconnectionState.RECONNECTING)
+        self._notify_attempt(attempt, delay)
+        max_str = "∞" if self.max_retries is None else str(self.max_retries)
+        logger.info(
+            f"Reconnection attempt {attempt}/{max_str}, waiting {delay:.1f}s..."
+        )
+
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            self._cancelled = True
+            break
+
+if self._cancelled:
+    self._set_state(ReconnectionState.DISCONNECTED)
+    logger.info("Reconnection cancelled")
+    return False
+
+self._set_state(ReconnectionState.FAILED)
+logger.error(f"Reconnection failed after {self.max_retries} attempts")
+return False
+```
+
+The key changes vs the original:
+- New `_should_continue(attempt)` helper handles both bounded and unbounded.
+- The "Reconnection failed after N attempts" line is only reachable when `max_retries` is a positive int (because infinite mode exits only via cancel, which takes the earlier branch).
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run:
+```bash
+uv run pytest tests/unit/test_reconnect_manager.py::TestInfiniteRetries -v
+```
+
+Expected: all three pass.
+
+- [ ] **Step 7: Run the full reconnect test file to confirm no regression**
+
+Run:
+```bash
+uv run pytest tests/unit/test_reconnect_manager.py -v
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 8: Run mypy on the changed file**
+
+Run:
+```bash
+uv run mypy src/gc2_connect/utils/reconnect.py
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/gc2_connect/utils/reconnect.py tests/unit/test_reconnect_manager.py
+git commit -m "$(cat <<'EOF'
+feat: support infinite retries in ReconnectionManager
+
+Allow max_retries=None to mean "retry until cancel". The bounded-retry
+path is unchanged. Prepares ReconnectionManager for use by the GSPro
+client where the user expects indefinite reconnection after GSPro
+restarts or sleep/wake.
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate `GSProClient` to async I/O + update tests + ripple to callers
+
+**Why one task:** the public API of `GSProClient` changes (sync send methods become async, `*_async` wrappers go away). Callers in `connection_manager.py`, `shot_router.py`, `app.py`, plus tests in `conftest.py` and `test_gspro_heartbeat.py`, all depend on this surface and cannot stay green if updated piecemeal. We do it all in one task ending with a green test suite.
+
+**Files:**
+- Modify: `src/gc2_connect/gspro/client.py` (full rewrite of socket I/O — keep public surface for state-tracking properties like `match_started`, `hardware_ready`, `set_hardware_ready`, callback management; rewrite connect/disconnect/send/reader)
+- Modify: `src/gc2_connect/services/connection_manager.py:478-545` (async `send_status`, drop `*_async` suffixes)
+- Modify: `src/gc2_connect/services/shot_router.py:164` (one line: drop `_async` suffix)
+- Modify: `src/gc2_connect/ui/app.py:993-994` (await `send_status`)
+- Modify: `tests/conftest.py:299-315` (async fixture)
+- Modify: `tests/unit/test_gspro_heartbeat.py` (AsyncMock for `send_heartbeat`; replace `_socket` patching with `_writer` patching; affected tests become `async def`)
+- Create: `tests/integration/test_gspro_client_async.py`
+
+**Reference reading before starting:**
+- `docs/GSPRO_TCP_PROTOCOL.md` — sections 2 (framing), 4 (inbound), 5 (outbound), 6.4 (shutdown).
+- `docs/GsProApi.cs` — `SendDeviceRegistrationAsync` (line 309), `SendShotData` (359), `ReadLoop` (516), `SendBallStatus` (660), `SendHeartbeat` (884), `Disconnect` (319). Specifically note the `+ "\n"` on every write.
+- `tests/simulators/gspro/server.py` — `MockGSProServer` API.
+
+### Step group A — Write the new async tests
+
+- [ ] **Step 1: Read existing `MockGSProServer` API**
+
+Run:
+```bash
+sed -n '1,80p' tests/simulators/gspro/server.py
+sed -n '1,40p' tests/simulators/gspro/config.py
+```
+
+Note the methods you'll use: `async with MockGSProServer(config) as server`, `server.host`, `server.port`, `server.get_shots()`, `server.received_messages` (or similar — check what's exposed). If the mock server does not currently expose the raw received bytes, add an attribute `received_raw_bytes: list[bytes]` that the connection handler appends each chunk to. Make that addition in this step; commit it later with Task 2.
+
+- [ ] **Step 2: Create `tests/integration/test_gspro_client_async.py` with the file header**
+
+```python
+# ABOUTME: Integration tests for GSProClient async I/O behavior against MockGSProServer.
+# ABOUTME: Covers newline framing, keepalive, dropped-connection handling, and handshake.
+"""Async integration tests for GSProClient."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from unittest.mock import MagicMock
+
+import pytest
+
+from gc2_connect.gspro.client import GSProClient
+from gc2_connect.models import GC2BallStatus, GC2ShotData
+from tests.simulators.gspro.config import MockGSProServerConfig, ResponseType
+from tests.simulators.gspro.server import MockGSProServer
+```
+
+- [ ] **Step 3: Write failing test — outbound writes are newline-terminated**
+
+Append to `tests/integration/test_gspro_client_async.py`:
+
+```python
+class TestNewlineFraming:
+    @pytest.mark.asyncio
+    async def test_every_outbound_write_ends_in_newline(self) -> None:
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            connected = await client.connect()
+            assert connected
+
+            try:
+                # Send each of the three outbound message shapes
+                shot = GC2ShotData(
+                    ball_speed=140.0, launch_angle=12.0, horizontal_launch_angle=1.0,
+                    total_spin=2500.0, back_spin=2400.0, side_spin=-200.0,
+                )
+                await client.send_shot(shot)
+                await client.send_heartbeat()
+                await client.send_status(GC2BallStatus(flags=7, ball_count=1))
+
+                # Give the server a beat to receive
+                await asyncio.sleep(0.1)
+            finally:
+                await client.disconnect()
+
+            raw = b"".join(server.received_raw_bytes)
+            # Every JSON object on the wire must be \n-terminated
+            assert raw.count(b"\n") >= 4  # initial registration heartbeat + 3 above
+            # No object should be concatenated with another (each \n preceded by '}')
+            for idx, b in enumerate(raw):
+                if b == 0x0A:  # '\n'
+                    assert raw[idx - 1:idx] == b"}", \
+                        f"Newline at offset {idx} not preceded by '}}': context={raw[max(0,idx-20):idx+1]!r}"
+```
+
+- [ ] **Step 4: Write failing test — `SO_KEEPALIVE` is enabled after connect**
+
+Append:
+
+```python
+class TestKeepalive:
+    @pytest.mark.asyncio
+    async def test_so_keepalive_enabled_after_connect(self) -> None:
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            await client.connect()
+            try:
+                sock = client._writer.get_extra_info("socket")
+                ka = sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
+                assert ka == 1
+            finally:
+                await client.disconnect()
+```
+
+- [ ] **Step 5: Write failing test — reader loop handles dropped connection**
+
+Append:
+
+```python
+class TestDroppedConnection:
+    @pytest.mark.asyncio
+    async def test_reader_loop_triggers_disconnect_callback_on_eof(self) -> None:
+        disconnect_fired = asyncio.Event()
+
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            client.add_disconnect_callback(lambda: disconnect_fired.set())
+            await client.connect()
+
+            # Server abruptly closes all client connections.
+            await server.close_all_connections()
+
+            # Disconnect callback must fire within a reasonable window.
+            await asyncio.wait_for(disconnect_fired.wait(), timeout=2.0)
+            assert client.is_connected is False
+```
+
+> If `MockGSProServer` doesn't have `close_all_connections`, add it: a method that iterates active client writers and calls `writer.close(); await writer.wait_closed()` on each.
+
+- [ ] **Step 6: Write failing test — `send_shot` returns None and ack arrives via callback**
+
+Append:
+
+```python
+class TestSendShotReturnsNone:
+    @pytest.mark.asyncio
+    async def test_send_shot_returns_none_and_ack_arrives_via_callback(self) -> None:
+        async with MockGSProServer(MockGSProServerConfig(
+            response_type=ResponseType.SUCCESS,
+        )) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            await client.connect()
+
+            ack_received = asyncio.Event()
+            seen = []
+
+            def on_response(resp) -> None:
+                seen.append(resp)
+                if resp.Code == 200:
+                    ack_received.set()
+
+            client.add_response_callback(on_response)
+
+            try:
+                shot = GC2ShotData(
+                    ball_speed=140.0, launch_angle=12.0, horizontal_launch_angle=1.0,
+                    total_spin=2500.0, back_spin=2400.0, side_spin=-200.0,
+                )
+                result = await client.send_shot(shot)
+                assert result is None  # async send_shot no longer returns inline
+
+                await asyncio.wait_for(ack_received.wait(), timeout=2.0)
+                assert any(r.Code == 200 for r in seen)
+            finally:
+                await client.disconnect()
+```
+
+- [ ] **Step 7: Write failing test — bare `GSPro ready` handshake**
+
+Append:
+
+```python
+class TestBareHandshake:
+    @pytest.mark.asyncio
+    async def test_bare_gspro_ready_string_fires_match_started(self) -> None:
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            match_started = asyncio.Event()
+            client.add_match_started_callback(lambda: match_started.set())
+            await client.connect()
+
+            try:
+                # MockGSProServer needs an API for "send raw bytes to current client".
+                # Send the bare handshake (no JSON envelope, ends with newline).
+                await server.send_raw_to_clients(b"GSPro ready\n")
+                await asyncio.wait_for(match_started.wait(), timeout=2.0)
+                assert client.match_started is True
+            finally:
+                await client.disconnect()
+```
+
+> If `send_raw_to_clients` does not exist on `MockGSProServer`, add it in this task.
+
+- [ ] **Step 8: Run all new tests to confirm they fail**
+
+Run:
+```bash
+uv run pytest tests/integration/test_gspro_client_async.py -v
+```
+
+Expected: every test fails. Failures will mostly be `AttributeError` on `await client.connect()` (today `connect` is sync) and `await client.send_shot()` (today returns `GSProResponse | None`).
+
+### Step group B — Rewrite `GSProClient`
+
+- [ ] **Step 9: Open `src/gc2_connect/gspro/client.py` and read the full file**
+
+Run:
+```bash
+sed -n '1,200p' src/gc2_connect/gspro/client.py
+sed -n '200,400p' src/gc2_connect/gspro/client.py
+sed -n '400,584p' src/gc2_connect/gspro/client.py
+```
+
+Note the surface that must be **preserved exactly**:
+
+- Module-level constants: `DEFAULT_HOST`, `DEFAULT_PORT`, `HEARTBEAT_INTERVAL_SECONDS = 6.0`.
+- Properties: `is_connected`, `shot_number`, `current_player`, `match_started`, `hardware_ready`, `is_ready_to_report`.
+- State-tracking methods: `set_hardware_ready(bool)`.
+- Callback registration methods: `add_response_callback`, `remove_response_callback`, `add_disconnect_callback`, `remove_disconnect_callback`, `add_player_info_callback`, `remove_player_info_callback`, `add_match_started_callback`, `remove_match_started_callback`, `add_match_ended_callback`, `remove_match_ended_callback`.
+- Internal handlers: `_on_match_started`, `_on_match_ended`, `_handle_response` (logic unchanged; only the trigger mechanism shifts to async).
+- Private attribute `_shot_number` — `connection_manager.py:497` writes to it directly to restore shot count across reconnects. Keep it.
+
+Surface that **changes**:
+
+- `connect()` → `async def connect() -> bool`
+- `disconnect()` → `async def disconnect() -> None`
+- `send_shot(shot)` → `async def send_shot(shot: GC2ShotData) -> None`
+- `send_heartbeat()` → `async def send_heartbeat() -> None`
+- `send_status(status)` → `async def send_status(status: GC2BallStatus) -> None`
+- Remove: `connect_async`, `disconnect_async`, `send_shot_async`, `send_status_async`
+- Remove: `_socket` attribute. Add: `_reader: asyncio.StreamReader | None`, `_writer: asyncio.StreamWriter | None`.
+- `_send_message(message)` → `async def _send_message(message)` — no `expect_response` param, no return value, always appends `\n`, no stale-buffer-clear.
+
+- [ ] **Step 10: Rewrite `client.py` — top, imports, and class skeleton**
+
+Replace the imports and the class definition's `__init__` and constants. Here's the full new top of the file (replaces lines 1-70 approximately):
+
+```python
+# ABOUTME: TCP client for GSPro Open Connect API v1.
+# ABOUTME: Sends shot data to GSPro golf simulator and handles responses.
+"""GSPro Open Connect API v1 client (async)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import socket
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from gc2_connect.models import (
+    GC2BallStatus,
+    GC2ShotData,
+    GSProResponse,
+    GSProShotMessage,
+    GSProShotOptions,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _notify_callbacks(callbacks: list[Callable[..., None]], *args: Any) -> None:
+    """Invoke all callbacks with the given arguments, logging any errors."""
+    for callback in callbacks:
+        try:
+            callback(*args)
+        except Exception as e:
+            logger.error(f"Callback error: {e}")
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 921
+HEARTBEAT_INTERVAL_SECONDS = 6.0
+CONNECT_TIMEOUT_SECONDS = 5.0
+SHUTDOWN_GRACE_SECONDS = 0.250
+KEEPALIVE_IDLE_SECONDS = 30
+KEEPALIVE_INTVL_SECONDS = 10
+KEEPALIVE_CNT = 3
+
+
+class GSProClient:
+    """Async client for GSPro Open Connect API v1."""
+
+    def __init__(self, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT):
+        self.host = host
+        self.port = port
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._connected = False
+        self._shot_number = 0
+        self._current_player: dict[str, Any] | None = None
+
+        # Callbacks
+        self._response_callbacks: list[Callable[[GSProResponse], None]] = []
+        self._disconnect_callbacks: list[Callable[[], None]] = []
+        self._player_info_callbacks: list[Callable[[dict[str, Any]], None]] = []
+        self._match_started_callbacks: list[Callable[[], None]] = []
+        self._match_ended_callbacks: list[Callable[[], None]] = []
+
+        # Background tasks
+        self._reader_task: asyncio.Task[None] | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+        # Match state tracking for heartbeat logic
+        self._match_started = False
+        self._hardware_ready = False
+
+        # Register internal handlers for match state changes
+        self._match_started_callbacks.append(self._on_match_started)
+        self._match_ended_callbacks.append(self._on_match_ended)
+```
+
+- [ ] **Step 11: Keep the existing read-only properties and callback registration methods**
+
+These come straight after `__init__` and are **unchanged** from the current file (lines 71-168 of the existing client.py):
+
+- `is_connected`, `shot_number`, `current_player`, `match_started`, `hardware_ready`, `is_ready_to_report` properties.
+- `add_response_callback` / `remove_response_callback` / `_notify_response`.
+- `add_disconnect_callback` / `remove_disconnect_callback` / `_notify_disconnect`.
+- `add_player_info_callback` / `remove_player_info_callback`.
+- `add_match_started_callback` / `remove_match_started_callback`.
+- `add_match_ended_callback` / `remove_match_ended_callback`.
+
+Copy them over verbatim.
+
+- [ ] **Step 12: Rewrite `set_hardware_ready` to fire-and-forget a heartbeat task**
+
+Replace the existing `set_hardware_ready`:
+
+```python
+def set_hardware_ready(self, ready: bool) -> None:
+    """Update hardware ready state from GC2.
+
+    Called when GC2 status changes (FLAGS in 0M message).
+    """
+    if self._hardware_ready == ready:
+        return
+    self._hardware_ready = ready
+    if not self._match_started:
+        return
+    self._schedule_heartbeat()
+```
+
+Add a small helper later in the class:
+
+```python
+def _schedule_heartbeat(self) -> None:
+    """Fire-and-forget a heartbeat from a sync context."""
+    try:
+        asyncio.create_task(self.send_heartbeat())
+    except RuntimeError:
+        # No running event loop (e.g. sync-only test contexts).
+        logger.debug("No running loop; skipping heartbeat schedule")
+```
+
+- [ ] **Step 13: Rewrite the match-state handlers**
+
+Replace `_on_match_started` and `_on_match_ended`:
+
+```python
+def _on_match_started(self) -> None:
+    """Handle match started event (code 202)."""
+    if self._match_started:
+        return
+    self._match_started = True
+    self._start_heartbeat_timer()
+    self._schedule_heartbeat()
+
+def _on_match_ended(self) -> None:
+    """Handle match ended event (code 203)."""
+    if not self._match_started:
+        return
+    self._match_started = False
+    self._stop_heartbeat_timer()
+```
+
+- [ ] **Step 14: Rewrite the heartbeat timer plumbing**
+
+Replace `_start_heartbeat_timer`, `_stop_heartbeat_timer`, `_heartbeat_loop`:
+
+```python
+def _start_heartbeat_timer(self) -> None:
+    """Start the periodic heartbeat task."""
+    self._stop_heartbeat_timer()
+    try:
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        logger.info("GSPro heartbeat timer started")
+    except RuntimeError as e:
+        logger.debug(f"Could not start heartbeat timer (no event loop): {e}")
+
+def _stop_heartbeat_timer(self) -> None:
+    """Stop the periodic heartbeat task."""
+    if self._heartbeat_task is not None:
+        self._heartbeat_task.cancel()
+        self._heartbeat_task = None
+        logger.info("GSPro heartbeat timer stopped")
+
+async def _heartbeat_loop(self) -> None:
+    """Send heartbeats at regular intervals while match is active."""
+    try:
+        while self._connected and self._match_started:
+            await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+            if self._connected and self._match_started:
+                await self.send_heartbeat()
+    except asyncio.CancelledError:
+        pass
+```
+
+- [ ] **Step 15: Add socket configuration helper**
+
+Add this method to the class:
+
+```python
+def _configure_socket(self, sock: socket.socket) -> None:
+    """Apply TCP_NODELAY and SO_KEEPALIVE to the underlying socket."""
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    if sys.platform == "darwin" and hasattr(socket, "TCP_KEEPALIVE"):
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, KEEPALIVE_IDLE_SECONDS)
+    elif sys.platform.startswith("linux"):
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, KEEPALIVE_IDLE_SECONDS)
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, KEEPALIVE_INTVL_SECONDS)
+        if hasattr(socket, "TCP_KEEPCNT"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, KEEPALIVE_CNT)
+```
+
+- [ ] **Step 16: Rewrite `connect` as async**
+
+```python
+async def connect(self) -> bool:
+    """Connect to GSPro and send the initial registration heartbeat."""
+    try:
+        self._reader, self._writer = await asyncio.wait_for(
+            asyncio.open_connection(self.host, self.port),
+            timeout=CONNECT_TIMEOUT_SECONDS,
+        )
+    except (TimeoutError, asyncio.TimeoutError, OSError) as e:
+        logger.error(f"Failed to connect to GSPro: {e}")
+        self._reader = None
+        self._writer = None
+        self._connected = False
+        return False
+
+    sock = self._writer.get_extra_info("socket")
+    if sock is not None:
+        self._configure_socket(sock)
+
+    self._connected = True
+    logger.info(f"Connected to GSPro at {self.host}:{self.port}")
+
+    # Initial registration heartbeat
+    logger.info("Sending initial heartbeat to GSPro...")
+    await self.send_heartbeat()
+    logger.info("Initial heartbeat sent")
+
+    # Start the inbound reader task
+    self._reader_task = asyncio.create_task(self._reader_loop())
+
+    return True
+```
+
+- [ ] **Step 17: Rewrite `disconnect` as async**
+
+```python
+async def disconnect(self) -> None:
+    """Cleanly disconnect from GSPro."""
+    if self._writer is None and not self._connected:
+        return
+
+    # Stop heartbeat first so it does not race with shutdown
+    self._stop_heartbeat_timer()
+    self._match_started = False
+
+    # Stop the reader task
+    if self._reader_task is not None:
+        self._reader_task.cancel()
+        self._reader_task = None
+
+    # Final shutdown heartbeat (LaunchMonitorIsReady=false)
+    if self._writer is not None and self._connected:
+        try:
+            await self._send_shutdown_heartbeat()
+            await asyncio.sleep(SHUTDOWN_GRACE_SECONDS)
+        except Exception as e:
+            logger.debug(f"Error sending shutdown heartbeat: {e}")
+
+    # Close the writer
+    if self._writer is not None:
+        try:
+            self._writer.close()
+            await self._writer.wait_closed()
+        except Exception:
+            pass
+
+    self._reader = None
+    self._writer = None
+    self._connected = False
+    self._shot_number = 0
+    self._current_player = None
+    logger.info("Disconnected from GSPro (clean shutdown)")
+```
+
+- [ ] **Step 18: Rewrite `_send_shutdown_heartbeat` as async**
+
+```python
+async def _send_shutdown_heartbeat(self) -> None:
+    """Send final heartbeat indicating launch monitor is going offline."""
+    if self._writer is None:
+        return
+    message = GSProShotMessage(
+        ShotNumber=self._shot_number,
+        ShotDataOptions=GSProShotOptions(
+            ContainsBallData=False,
+            ContainsClubData=False,
+            LaunchMonitorIsReady=False,
+            IsHeartBeat=True,
+        ),
+    )
+    payload = json.dumps(message.to_dict()).encode("utf-8") + b"\n"
+    self._writer.write(payload)
+    await self._writer.drain()
+    logger.debug("Sent shutdown heartbeat (LaunchMonitorIsReady=false)")
+```
+
+- [ ] **Step 19: Rewrite the three public send methods**
+
+```python
+async def send_shot(self, shot: GC2ShotData) -> None:
+    """Send a shot to GSPro.
+
+    Returns immediately after writing. The GSPro ack arrives asynchronously
+    through the reader loop and is dispatched to response callbacks.
+    """
+    if not self._connected or self._writer is None:
+        logger.error("Not connected to GSPro")
+        return
+
+    self._shot_number += 1
+    message = GSProShotMessage.from_gc2_shot(shot, self._shot_number)
+    await self._send_message(message)
+
+async def send_heartbeat(self) -> None:
+    """Send a periodic heartbeat. GSPro does not respond to heartbeats."""
+    if not self._connected or self._writer is None:
+        return
+    message = GSProShotMessage(
+        ShotNumber=self._shot_number,
+        ShotDataOptions=GSProShotOptions(
+            ContainsBallData=False,
+            ContainsClubData=False,
+            LaunchMonitorIsReady=self.is_ready_to_report,
+            IsHeartBeat=True,
+        ),
+    )
+    await self._send_message(message)
+
+async def send_status(self, status: GC2BallStatus) -> None:
+    """Send an event-driven status update. GSPro does not respond."""
+    if not self._connected or self._writer is None:
+        return
+    message = GSProShotMessage(
+        ShotNumber=self._shot_number,
+        ShotDataOptions=GSProShotOptions(
+            ContainsBallData=False,
+            ContainsClubData=False,
+            LaunchMonitorIsReady=status.is_ready,
+            LaunchMonitorBallDetected=status.ball_detected,
+            IsHeartBeat=False,
+        ),
+    )
+    logger.debug(
+        f"Sending status: ready={status.is_ready}, ball_detected={status.ball_detected}"
+    )
+    await self._send_message(message)
+```
+
+- [ ] **Step 20: Rewrite `_send_message` as async with newline framing**
+
+```python
+async def _send_message(self, message: GSProShotMessage) -> None:
+    """Send a single JSON object, newline-terminated."""
+    if self._writer is None:
+        logger.error("Cannot send message: writer is None")
+        return
+
+    payload = json.dumps(message.to_dict()).encode("utf-8") + b"\n"
+    try:
+        self._writer.write(payload)
+        await self._writer.drain()
+        logger.debug(f"Sent {len(payload)} bytes: {payload[:200]!r}")
+    except (ConnectionError, OSError) as e:
+        logger.error(f"GSPro write failed: {e}")
+        self._on_connection_lost()
+```
+
+- [ ] **Step 21: Add the reader loop and buffer-drain helper**
+
+```python
+async def _reader_loop(self) -> None:
+    """Continuously read from GSPro and dispatch responses."""
+    logger.debug("GSPro reader loop started")
+    buffer = b""
+    try:
+        while self._connected and self._reader is not None:
+            try:
+                chunk = await self._reader.read(4096)
+            except (ConnectionError, OSError) as e:
+                logger.warning(f"GSPro reader socket error: {e}")
+                self._on_connection_lost()
+                return
+            if not chunk:
+                logger.warning("GSPro connection closed (EOF)")
+                self._on_connection_lost()
+                return
+            buffer = self._drain_buffer(buffer + chunk)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        logger.info("GSPro reader loop ended")
+
+def _drain_buffer(self, buffer: bytes) -> bytes:
+    """Extract every complete JSON object (or bare 'GSPro ready') from buffer.
+
+    Returns the unparsed tail.
+    """
+    text = buffer.decode("utf-8", errors="replace")
+    decoder = json.JSONDecoder()
+
+    while text:
+        # Skip leading whitespace, including \r and \n
+        stripped = text.lstrip()
+        if not stripped:
+            return b""
+        skipped = len(text) - len(stripped)
+        text = stripped
+
+        # Bare handshake line?
+        if text.startswith("GSPro ready"):
+            self._handle_response({"Code": 202, "Message": "GSPro ready"})
+            # Drop up to and including the next newline (or whole line)
+            newline = text.find("\n")
+            if newline == -1:
+                return b""  # rest will arrive later
+            text = text[newline + 1:]
+            continue
+
+        # Try to parse one JSON object off the front
+        try:
+            obj, end = decoder.raw_decode(text)
+        except json.JSONDecodeError:
+            # Possibly an incomplete object — keep waiting for more bytes.
+            return (skipped * b" " + text.encode("utf-8")) if skipped else text.encode("utf-8")
+
+        self._handle_response(obj)
+        text = text[end:]
+
+    return b""
+```
+
+> The "skipped * b' '" trick on the JSONDecodeError branch preserves byte-level offsets for clean logging if needed; functionally `text.encode()` alone is fine. Either is acceptable.
+
+- [ ] **Step 22: Add the connection-lost helper**
+
+```python
+def _on_connection_lost(self) -> None:
+    """Mark disconnected and notify callbacks. Idempotent."""
+    if not self._connected:
+        return
+    self._connected = False
+    self._stop_heartbeat_timer()
+    self._match_started = False
+    # Best-effort writer close; do not await here (we might be in a sync context).
+    if self._writer is not None:
+        try:
+            self._writer.close()
+        except Exception:
+            pass
+    self._notify_disconnect()
+```
+
+- [ ] **Step 23: Keep `_handle_response` as-is**
+
+The current `_handle_response` (lines 222-246 of the old file) does not need any change — it just inspects `Code` and fires callbacks. Copy it verbatim.
+
+- [ ] **Step 24: Delete the obsolete methods**
+
+The new `client.py` must **not** contain:
+
+- `_start_reader_loop` (the old `try/except` task-starter).
+- `_stop_reader_loop`.
+- `connect_async`, `disconnect_async`, `send_shot_async`, `send_status_async`.
+- The old sync `connect`, `disconnect`, `send_shot`, `send_heartbeat`, `send_status`, `_send_message`, `_send_shutdown_heartbeat`.
+- The `_reader_running` flag.
+- Any reference to `self._socket`.
+
+Verify with:
+```bash
+grep -n "connect_async\|disconnect_async\|send_shot_async\|send_status_async\|_socket\|_reader_running" src/gc2_connect/gspro/client.py
+```
+
+Expected output: empty.
+
+### Step group C — Update tests for the new API
+
+- [ ] **Step 25: Update `tests/conftest.py::gspro_client` fixture**
+
+Replace lines 299-315 of `tests/conftest.py`:
+
+```python
+@pytest.fixture
+async def gspro_client(mock_gspro_server):
+    """Fixture providing a GSProClient connected to the mock server."""
+    from gc2_connect.gspro.client import GSProClient
+
+    client = GSProClient(host=mock_gspro_server.host, port=mock_gspro_server.port)
+    connected = await client.connect()
+    assert connected, "Failed to connect to mock GSPro server"
+
+    # Give the initial registration heartbeat a moment to land
+    await asyncio.sleep(0.05)
+
+    try:
+        yield client
+    finally:
+        if client.is_connected:
+            await client.disconnect()
+```
+
+If `asyncio` is not already imported at the top of `conftest.py`, add `import asyncio`.
+
+- [ ] **Step 26: Update `tests/unit/test_gspro_heartbeat.py` connected-client fixture**
+
+The fixture at lines 21-27 puts `MagicMock` on `_socket`. Replace with a `MagicMock` writer that supports `write` (sync) and `drain` (async):
+
+```python
+@pytest.fixture
+def connected_client() -> Generator[GSProClient, None, None]:
+    """Create a GSProClient that appears connected, with a mocked writer."""
+    client = GSProClient()
+    client._connected = True
+    writer = MagicMock()
+    writer.write = MagicMock()
+    writer.drain = AsyncMock()
+    client._writer = writer
+    yield client
+```
+
+Add `from unittest.mock import AsyncMock` to the imports at the top of the file (alongside the existing `MagicMock, patch`).
+
+- [ ] **Step 27: Update `TestSetHardwareReady` tests**
+
+The test bodies at lines 74-94 patch `send_heartbeat` as a sync method and assert `assert_called_once()`. `send_heartbeat` is now async; with our `_schedule_heartbeat()` helper, `set_hardware_ready` now calls `asyncio.create_task(self.send_heartbeat())`. The right assertion is that `asyncio.create_task` was called with the right coroutine.
+
+Replace lines 74-94 with:
+
+```python
+def test_set_hardware_ready_sends_status_during_match(
+    self, connected_client: GSProClient
+) -> None:
+    """Test set_hardware_ready schedules a heartbeat when match is active."""
+    connected_client._match_started = True
+
+    with patch.object(connected_client, "_schedule_heartbeat") as mock_schedule:
+        connected_client.set_hardware_ready(True)
+        mock_schedule.assert_called_once()
+
+def test_set_hardware_ready_no_status_when_no_match(
+    self, connected_client: GSProClient
+) -> None:
+    """Test set_hardware_ready doesn't schedule a heartbeat when no match is active."""
+    connected_client._match_started = False
+
+    with patch.object(connected_client, "_schedule_heartbeat") as mock_schedule:
+        connected_client.set_hardware_ready(True)
+        mock_schedule.assert_not_called()
+
+def test_set_hardware_ready_no_status_when_value_unchanged(
+    self, connected_client: GSProClient
+) -> None:
+    """Test set_hardware_ready doesn't schedule a heartbeat when value doesn't change."""
+    connected_client._match_started = True
+    connected_client._hardware_ready = True
+
+    with patch.object(connected_client, "_schedule_heartbeat") as mock_schedule:
+        connected_client.set_hardware_ready(True)
+        mock_schedule.assert_not_called()
+```
+
+- [ ] **Step 28: Update `TestOnMatchStarted` tests**
+
+Replace lines 112-155 (`test_on_match_started_*` tests). The handler now also goes through `_schedule_heartbeat`:
+
+```python
+class TestOnMatchStarted:
+    """Test _on_match_started internal handler."""
+
+    def test_on_match_started_sets_flag(self, connected_client: GSProClient) -> None:
+        assert connected_client._match_started is False
+        with (
+            patch.object(connected_client, "_start_heartbeat_timer"),
+            patch.object(connected_client, "_schedule_heartbeat"),
+        ):
+            connected_client._on_match_started()
+        assert connected_client._match_started is True
+
+    def test_on_match_started_starts_heartbeat_timer(self, connected_client: GSProClient) -> None:
+        with (
+            patch.object(connected_client, "_start_heartbeat_timer") as mock_start_timer,
+            patch.object(connected_client, "_schedule_heartbeat"),
+        ):
+            connected_client._on_match_started()
+            mock_start_timer.assert_called_once()
+
+    def test_on_match_started_sends_status(self, connected_client: GSProClient) -> None:
+        with (
+            patch.object(connected_client, "_start_heartbeat_timer"),
+            patch.object(connected_client, "_schedule_heartbeat") as mock_schedule,
+        ):
+            connected_client._on_match_started()
+            mock_schedule.assert_called_once()
+
+    def test_on_match_started_idempotent(self, connected_client: GSProClient) -> None:
+        connected_client._match_started = True
+        with (
+            patch.object(connected_client, "_start_heartbeat_timer") as mock_start_timer,
+            patch.object(connected_client, "_schedule_heartbeat") as mock_schedule,
+        ):
+            connected_client._on_match_started()
+            mock_start_timer.assert_not_called()
+            mock_schedule.assert_not_called()
+```
+
+- [ ] **Step 29: Update `TestHeartbeatLoop` tests**
+
+The loop now `await`s `send_heartbeat`. Replace `patch.object(connected_client, "send_heartbeat", side_effect=...)` with `AsyncMock(side_effect=...)`. Replace lines 238-301 with:
+
+```python
+class TestHeartbeatLoop:
+    """Test the heartbeat loop behavior."""
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_sends_heartbeats(self, connected_client: GSProClient) -> None:
+        connected_client._match_started = True
+        heartbeat_count = 0
+
+        async def mock_send_heartbeat() -> None:
+            nonlocal heartbeat_count
+            heartbeat_count += 1
+            if heartbeat_count >= 2:
+                connected_client._match_started = False
+
+        with (
+            patch.object(connected_client, "send_heartbeat", new=AsyncMock(side_effect=mock_send_heartbeat)),
+            patch("asyncio.sleep", new=AsyncMock(return_value=None)) as mock_sleep,
+        ):
+            await connected_client._heartbeat_loop()
+            assert heartbeat_count == 2
+            assert mock_sleep.call_count >= 1
+            mock_sleep.assert_called_with(HEARTBEAT_INTERVAL_SECONDS)
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_stops_on_disconnect(self, connected_client: GSProClient) -> None:
+        connected_client._match_started = True
+        iteration = 0
+
+        async def mock_sleep(_seconds: float) -> None:
+            nonlocal iteration
+            iteration += 1
+            if iteration >= 1:
+                connected_client._connected = False
+
+        with (
+            patch.object(connected_client, "send_heartbeat", new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock(side_effect=mock_sleep)),
+        ):
+            await connected_client._heartbeat_loop()
+            assert iteration >= 1
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_loop_stops_on_match_ended(self, connected_client: GSProClient) -> None:
+        connected_client._match_started = True
+        iteration = 0
+
+        async def mock_sleep(_seconds: float) -> None:
+            nonlocal iteration
+            iteration += 1
+            if iteration >= 1:
+                connected_client._match_started = False
+
+        with (
+            patch.object(connected_client, "send_heartbeat", new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock(side_effect=mock_sleep)),
+        ):
+            await connected_client._heartbeat_loop()
+            assert iteration >= 1
+```
+
+- [ ] **Step 30: Update `TestSendHeartbeatWithReadyState` tests**
+
+Lines 307-345 assert on `mock_socket.sendall` and check the decoded bytes. Replace with assertions on `writer.write`. These tests are now async:
+
+```python
+class TestSendHeartbeatWithReadyState:
+    """Test that send_heartbeat uses is_ready_to_report."""
+
+    @pytest.mark.asyncio
+    async def test_send_heartbeat_uses_is_ready_to_report_true(
+        self, connected_client: GSProClient
+    ) -> None:
+        connected_client._hardware_ready = True
+        connected_client._match_started = True
+
+        writer = connected_client._writer
+        assert writer is not None
+
+        await connected_client.send_heartbeat()
+
+        writer.write.assert_called_once()
+        sent_data = writer.write.call_args[0][0].decode("utf-8")
+        assert sent_data.endswith("\n"), "outbound payload must end with \\n"
+        assert '"LaunchMonitorIsReady": true' in sent_data
+
+    @pytest.mark.asyncio
+    async def test_send_heartbeat_uses_is_ready_to_report_false(
+        self, connected_client: GSProClient
+    ) -> None:
+        connected_client._hardware_ready = True
+        connected_client._match_started = False
+
+        writer = connected_client._writer
+        assert writer is not None
+
+        await connected_client.send_heartbeat()
+
+        writer.write.assert_called_once()
+        sent_data = writer.write.call_args[0][0].decode("utf-8")
+        assert sent_data.endswith("\n")
+        assert '"LaunchMonitorIsReady": false' in sent_data
+```
+
+- [ ] **Step 31: Update `TestDisconnectStopsHeartbeat`**
+
+Lines 351-369 — `disconnect` is now async. Make those tests async and use `AsyncMock` for `_send_shutdown_heartbeat`:
+
+```python
+class TestDisconnectStopsHeartbeat:
+    """Test that disconnect stops the heartbeat timer."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_stops_heartbeat_timer(self, connected_client: GSProClient) -> None:
+        mock_task = MagicMock()
+        connected_client._heartbeat_task = mock_task
+        with patch.object(connected_client, "_send_shutdown_heartbeat", new=AsyncMock()):
+            await connected_client.disconnect()
+        mock_task.cancel.assert_called_once()
+        assert connected_client._heartbeat_task is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_match_state(self, connected_client: GSProClient) -> None:
+        connected_client._match_started = True
+        with patch.object(connected_client, "_send_shutdown_heartbeat", new=AsyncMock()):
+            await connected_client.disconnect()
+        assert connected_client._match_started is False
+```
+
+- [ ] **Step 32: Confirm the remaining tests in `test_gspro_heartbeat.py` need no change**
+
+`TestMatchStateTracking`, `TestHeartbeatTimerControl`, `TestOnMatchEnded`, `TestMatchStateCallbackWiring`, `TestHeartbeatIntervalConstant`, `TestInitializationWithCallbacks` all exercise sync property logic. They do not need updates. Run them as a sanity check:
+
+```bash
+uv run pytest tests/unit/test_gspro_heartbeat.py::TestMatchStateTracking tests/unit/test_gspro_heartbeat.py::TestHeartbeatTimerControl tests/unit/test_gspro_heartbeat.py::TestOnMatchEnded tests/unit/test_gspro_heartbeat.py::TestMatchStateCallbackWiring tests/unit/test_gspro_heartbeat.py::TestHeartbeatIntervalConstant tests/unit/test_gspro_heartbeat.py::TestInitializationWithCallbacks -v
+```
+
+Expected: all pass.
+
+### Step group D — Update callers
+
+- [ ] **Step 33: Update `services/connection_manager.py::GSProConnectionManager`**
+
+Replace lines 478-545 with:
+
+```python
+async def connect(self, host: str, port: int) -> bool:
+    """Connect to GSPro."""
+    if self._client is not None:
+        await self.disconnect()
+
+    self._host = host
+    self._port = port
+    self._client = GSProClient(host=host, port=port)
+    self._client.add_disconnect_callback(self._on_disconnect)
+
+    # Restore shot number from our persistent storage
+    self._client._shot_number = self._shot_number
+
+    success = await self._client.connect()
+    self._callback_registry.notify_gspro_connect(success)
+
+    if success:
+        logger.info(f"GSPro connected to {host}:{port} via connection manager")
+    else:
+        logger.warning(f"GSPro connection to {host}:{port} failed")
+        self._client = None
+
+    return success
+
+async def disconnect(self) -> None:
+    """Disconnect from GSPro."""
+    if self._client is not None:
+        # Save shot number before disconnect (client resets it)
+        self._shot_number = self._client.shot_number
+        await self._client.disconnect()
+        self._client = None
+    logger.info("GSPro disconnected via connection manager")
+
+async def send_shot(self, shot: GC2ShotData) -> None:
+    """Send shot to GSPro."""
+    if self._client is None or not self._client.is_connected:
+        logger.warning("Cannot send shot: GSPro not connected")
+        return
+
+    await self._client.send_shot(shot)
+    self._shot_number = self._client.shot_number
+
+async def send_status(self, status: GC2BallStatus) -> None:
+    """Send ball status to GSPro."""
+    if self._client is not None and self._client.is_connected:
+        await self._client.send_status(status)
+```
+
+Notes:
+- `disconnect` was sync; it's now async. The only caller that triggers it from a sync context is `_on_disconnect` (line 547) — see Step 34.
+- `send_shot` no longer returns a response; if any caller used the return value (line 269 of the same file: `response = await self._gspro_mgr.send_shot(shot)`), update the caller too (it is fine to ignore the now-`None` return).
+
+- [ ] **Step 34: Update `_on_disconnect` and any sync disconnect callers in `connection_manager.py`**
+
+Search for any callers of `self.disconnect()` inside `GSProConnectionManager`:
+
+```bash
+grep -n "self\.disconnect()\|self\._client\.disconnect" src/gc2_connect/services/connection_manager.py
+```
+
+Any sync callers (e.g. `_on_disconnect`, or a shutdown handler) need to be async or to schedule the disconnect with `asyncio.create_task(self.disconnect())`. Pick whichever matches the surrounding context:
+
+- If the caller is itself async, `await self.disconnect()`.
+- If the caller is sync and inside a running event loop (callback from the client), `asyncio.create_task(self.disconnect())`.
+
+Apply the appropriate fix in each call site within `connection_manager.py`.
+
+- [ ] **Step 35: Update `services/shot_router.py:164`**
+
+Change:
+```python
+await self._gspro_client.send_shot_async(shot)
+```
+to:
+```python
+await self._gspro_client.send_shot(shot)
+```
+
+- [ ] **Step 36: Update `ui/app.py:993-994`**
+
+The current code:
+```python
+if self.send_status_to_gspro and self._gspro_mgr.is_connected:
+    self._gspro_mgr.send_status(status)
+```
+becomes:
+```python
+if self.send_status_to_gspro and self._gspro_mgr.is_connected:
+    await self._gspro_mgr.send_status(status)
+```
+
+Verify the enclosing function is `async def`. If it is not (it should be — it's inside the GC2 status handler chain which is async), promote it. Run:
+
+```bash
+sed -n '950,1000p' src/gc2_connect/ui/app.py
+```
+
+Confirm the enclosing function declaration is `async def`.
+
+- [ ] **Step 37: Check for any other call sites you might have missed**
+
+Run:
+```bash
+grep -rn "send_shot_async\|send_status_async\|connect_async\|disconnect_async" src/ tests/
+```
+
+Expected: empty. If anything turns up, update it (drop the `_async` suffix and add `await`).
+
+### Step group E — Run the full suite
+
+- [ ] **Step 38: Run the new integration tests**
+
+Run:
+```bash
+uv run pytest tests/integration/test_gspro_client_async.py -v
+```
+
+Expected: all five tests pass (newline framing, keepalive, dropped connection, send_shot returns None + ack via callback, bare handshake).
+
+- [ ] **Step 39: Run the heartbeat unit tests**
+
+Run:
+```bash
+uv run pytest tests/unit/test_gspro_heartbeat.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 40: Run the full pytest suite**
+
+Run:
+```bash
+uv run pytest
+```
+
+Expected: 0 failures. If a test fails, fix it before continuing — do not move on.
+
+- [ ] **Step 41: Run mypy**
+
+Run:
+```bash
+uv run mypy src/
+```
+
+Expected: 0 errors. Likely fix-ups: type narrowing on `self._writer` (use `assert self._writer is not None` at the top of methods that touch it after the `is_connected` check).
+
+- [ ] **Step 42: Run ruff lint and format check**
+
+Run:
+```bash
+uv run ruff check . && uv run ruff format --check .
+```
+
+Expected: clean. If formatting fails, run `uv run ruff format .` and re-check.
+
+- [ ] **Step 43: Commit**
+
+```bash
+git add src/gc2_connect/gspro/client.py \
+        src/gc2_connect/services/connection_manager.py \
+        src/gc2_connect/services/shot_router.py \
+        src/gc2_connect/ui/app.py \
+        tests/conftest.py \
+        tests/unit/test_gspro_heartbeat.py \
+        tests/integration/test_gspro_client_async.py \
+        tests/simulators/gspro/server.py
+git commit -m "$(cat <<'EOF'
+refactor: migrate GSPro client to asyncio.open_connection
+
+Replace sync socket + run_in_executor wrappers with native asyncio
+StreamReader/StreamWriter. All send_* methods become async; send_shot
+returns None (the ack arrives through the reader loop's response
+callbacks). Append \n to every outbound JSON write, matching the
+GsProApi.cs reference. Enable SO_KEEPALIVE with platform-appropriate
+idle/interval/count on connect.
+
+Update callers in connection_manager, shot_router, and the UI app to
+the new async API. Migrate tests/conftest.py gspro_client fixture
+and tests/unit/test_gspro_heartbeat.py to AsyncMock + writer patches.
+Add tests/integration/test_gspro_client_async.py covering newline
+framing, keepalive, dropped-connection handling, send_shot return
+shape, and the bare "GSPro ready" handshake.
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire infinite reconnect for GSPro + capped-backoff test
+
+**Files:**
+- Modify: `src/gc2_connect/services/connection_manager.py` (where the GSPro `ReconnectionManager` is instantiated)
+- Modify: `tests/unit/test_reconnect_manager.py` (append capped-backoff test)
+
+- [ ] **Step 1: Locate the GSPro `ReconnectionManager` instantiation**
+
+Run:
+```bash
+grep -n "ReconnectionManager" src/gc2_connect/services/connection_manager.py src/gc2_connect/ui/app.py
+```
+
+Identify the line where the GSPro `ReconnectionManager` is constructed. (USB-side `ReconnectionManager` is also nearby — do **not** touch it.)
+
+- [ ] **Step 2: Update the GSPro `ReconnectionManager` defaults**
+
+Replace the GSPro construction with:
+
+```python
+ReconnectionManager(
+    max_retries=None,   # retry forever; user cancels via Disconnect
+    base_delay=5.0,
+    max_delay=60.0,
+)
+```
+
+- [ ] **Step 3: Write a unit test for the capped backoff sequence**
+
+Append to `tests/unit/test_reconnect_manager.py`:
+
+```python
+class TestCappedBackoff:
+    """Test the 5s -> 60s capped exponential backoff used for GSPro."""
+
+    def test_gspro_backoff_sequence(self) -> None:
+        mgr = ReconnectionManager(max_retries=None, base_delay=5.0, max_delay=60.0)
+        delays = [mgr.get_delay_for_attempt(i) for i in range(7)]
+        assert delays == [5.0, 10.0, 20.0, 40.0, 60.0, 60.0, 60.0]
+```
+
+- [ ] **Step 4: Run the new test**
+
+Run:
+```bash
+uv run pytest tests/unit/test_reconnect_manager.py::TestCappedBackoff -v
+```
+
+Expected: pass. (No code change should be needed; this is a property assertion on the existing `get_delay_for_attempt` algorithm with new defaults.)
+
+- [ ] **Step 5: Run full CI suite**
+
+Run:
+```bash
+uv run pytest && uv run mypy src/ && uv run ruff check . && uv run ruff format --check .
+```
+
+Expected: all clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gc2_connect/services/connection_manager.py tests/unit/test_reconnect_manager.py
+git commit -m "$(cat <<'EOF'
+feat: GSPro reconnect retries forever with 5s-60s capped backoff
+
+Default GSPro ReconnectionManager to max_retries=None and base/max
+delay of 5s/60s. When GSPro restarts, sleeps, or otherwise vanishes,
+the client now keeps trying indefinitely until the user explicitly
+disconnects.
+EOF
+)"
+```
+
+---
+
+## Task 4: Manual smoke test against the mock server
+
+**Why:** verifies the async path works end-to-end and exercises a real reconnect cycle, which the automated tests only approximate.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Start the mock GSPro server in a separate terminal**
+
+```bash
+uv run python tools/mock_gspro_server.py --host 0.0.0.0 --port 921
+```
+
+- [ ] **Step 2: Start the app**
+
+```bash
+uv run python -m gc2_connect.main
+```
+
+- [ ] **Step 3: Connect to GSPro from the UI**
+
+Use the GSPro panel to connect to `127.0.0.1:921`. Confirm "Connected" state.
+
+- [ ] **Step 4: Fire a test shot**
+
+If mock GC2 mode is available, fire a test shot. Confirm in the mock server's terminal that the shot JSON arrived and ended with a newline (the mock server typically logs raw bytes).
+
+- [ ] **Step 5: Kill the mock server mid-session**
+
+In the mock-server terminal, `Ctrl+C` it.
+
+- [ ] **Step 6: Confirm the client transitions to Reconnecting**
+
+The UI should display a "Reconnecting…" indicator. Wait at least 90 seconds and confirm the client is still attempting reconnects — the previous 31-second bound is gone.
+
+- [ ] **Step 7: Restart the mock server**
+
+```bash
+uv run python tools/mock_gspro_server.py --host 0.0.0.0 --port 921
+```
+
+- [ ] **Step 8: Confirm the client reconnects automatically**
+
+Within ~60 seconds (one cap interval) the client should reconnect, the UI should return to "Connected", and shots should send again.
+
+- [ ] **Step 9: Hit "Disconnect" mid-reconnect**
+
+Kill the mock server again, wait until the UI shows Reconnecting, then click Disconnect. Confirm the loop stops and the UI returns to a clean disconnected state.
+
+- [ ] **Step 10: Record results**
+
+If everything passed, no code change. Note any anomalies in a follow-up.
+
+---
+
+## Spec coverage check
+
+Walking back through `docs/superpowers/specs/2026-05-11-gspro-client-async-migration-design.md`:
+
+| Spec item | Implemented in |
+|---|---|
+| Outbound `\n` framing | Task 2 (Steps 18, 20); test in Task 2 Step 3 |
+| `SO_KEEPALIVE` with platform-specific tuning | Task 2 Step 15; test Step 4 |
+| `asyncio.open_connection` migration | Task 2 Step 16 |
+| `_send_message` async + drops `expect_response` + drops stale-buffer-clear | Task 2 Step 20 |
+| `send_shot` returns `None` | Task 2 Step 19; test Step 6 |
+| Reader loop via StreamReader with `_drain_buffer` fallback | Task 2 Step 21; test Step 5 |
+| Bare `GSPro ready` handshake | Task 2 Step 21; test Step 7 |
+| `disconnect` async with `writer.close()` + `wait_closed()` | Task 2 Step 17 |
+| Remove `*_async` sync wrappers | Task 2 Steps 24, 33-37 |
+| `_on_match_started`, `set_hardware_ready` schedule via `create_task` | Task 2 Steps 12, 13; tests in Steps 27, 28 |
+| `ReconnectionManager.max_retries: int \| None = None` | Task 1 Steps 4, 5; tests Step 2 |
+| GSPro reconnect defaults (None, 5s, 60s) | Task 3 Step 2; test Step 3 |
+| Caller ripple in connection_manager / shot_router / app | Task 2 Steps 33-36 |
+| `conftest.py` fixture async | Task 2 Step 25 |
+| `test_gspro_heartbeat.py` AsyncMock updates | Task 2 Steps 26-31 |
+| Manual smoke test | Task 4 |
+
+Spec is fully covered.

--- a/docs/superpowers/specs/2026-05-11-gspro-client-async-migration-design.md
+++ b/docs/superpowers/specs/2026-05-11-gspro-client-async-migration-design.md
@@ -1,0 +1,257 @@
+# GSPro Client Modernization — Design
+
+**Status:** Design, pending implementation
+**Date:** 2026-05-11
+**Author:** Samiur + assistant
+
+## Context
+
+The GSPro TCP client (`src/gc2_connect/gspro/client.py`) was authored around `socket.socket` with sync I/O wrapped in `asyncio.run_in_executor`. It works in production today, but three operational gaps have surfaced when compared against the OpenSkyPlus2 reference (`docs/GsProApi.cs`, the closest thing to an official wire spec):
+
+1. **No newline framing on outbound writes.** The reference appends `\n` to every JSON write. Our client used to (commit `76ff60d`) but a later refactor dropped it. Today this is benign because each `sendall` typically lands as one TCP packet, but it's not defensive against any future buffering, batched writes, or proxy.
+2. **No `SO_KEEPALIVE`.** If GSPro is hard-killed without a FIN, the reader loop sits silent forever and the existing reconnect path never triggers.
+3. **Reconnect window is short.** Current `ReconnectionManager` defaults give up after 5 attempts (1s → 16s, ~31s total). The user wants reconnect to keep trying indefinitely (matching the reference, where `MaxRetries < 0` means infinite).
+
+The reader loop also has a code-smell wart: it flips the socket between blocking and non-blocking on every iteration and busy-polls with `await asyncio.sleep(0.1)` on `BlockingIOError`. Cleanly fixed by migrating to `asyncio.open_connection`.
+
+A doc — `docs/GSPRO_TCP_PROTOCOL.md` — was dropped into the repo from a different launch-monitor's connector and contained wire-format claims (Message-string discriminator, no `IsHeartBeat`, sign-flipped spin) that contradict the actual GSPro v1.x protocol. The doc has been rewritten to describe the real wire, and is **not** the source of this design. The genuine source is `docs/GsProApi.cs` plus the working Python implementation.
+
+## Goals
+
+1. Adopt `\n` newline framing on every outbound JSON write.
+2. Enable `SO_KEEPALIVE` with platform-appropriate timing on connect.
+3. Migrate the client to `asyncio.open_connection` (StreamReader/StreamWriter), eliminating the sync-socket + `run_in_executor` pattern.
+4. Make `ReconnectionManager` support infinite retries and use it for GSPro with a 5s→60s capped exponential backoff.
+5. Keep the wire format and message semantics exactly as they are today (Code-based responses, `IsHeartBeat` flag, current sign conventions, `CarryDistance`, combined ball+club shot message).
+6. Preserve the existing reconnect-via-`GSProConnectionManager` flow; UI cancels via the existing Disconnect action.
+
+## Non-goals
+
+- Changing GC2 / USB-side code or its reconnect policy.
+- Changing the GSPro wire format (signs, fields, message split, etc.).
+- Adding new UI affordances. The existing Reconnecting state + Disconnect button handle cancellation.
+- Migrating to `pydantic` for the GSPro models. The current dataclass models stay.
+
+## Design
+
+### 1. Wire-format changes (small, isolated)
+
+In `GSProClient._send_message`:
+
+- Append `b"\n"` to every encoded payload: `payload = json.dumps(...).encode("utf-8") + b"\n"`.
+- Same change applies to `_send_shutdown_heartbeat` and any other outbound write.
+
+No other wire-format changes.
+
+### 2. `GSProClient` async migration
+
+`GSProClient` replaces sync sockets with `asyncio.StreamReader` / `StreamWriter`.
+
+**Connection.** `async def connect(self) -> bool`:
+
+```
+reader, writer = await asyncio.wait_for(
+    asyncio.open_connection(self.host, self.port),
+    timeout=5.0,
+)
+sock = writer.get_extra_info("socket")
+self._configure_socket(sock)         # TCP_NODELAY, SO_KEEPALIVE — see §3
+self._reader, self._writer = reader, writer
+self._connected = True
+await self._send_initial_heartbeat()  # registration
+self._start_reader_loop()
+return True
+```
+
+On failure (`asyncio.TimeoutError`, `OSError`): `self._connected = False`, log, return `False`. Caller (the `GSProConnectionManager` + `ReconnectionManager`) handles retry.
+
+**Send path.** All sends become `async`:
+
+- `async def send_shot(self, shot: GC2ShotData) -> None` — increments `_shot_number`, builds the message, calls `_send_message`. **Returns `None`.** Shot acks arrive asynchronously through the reader loop and fire response callbacks; `send_shot` no longer waits inline.
+- `async def send_heartbeat(self) -> None` — unchanged semantics.
+- `async def send_status(self, status: GC2BallStatus) -> None` — unchanged semantics.
+
+`_send_message` becomes async:
+
+```
+async def _send_message(self, message: GSProShotMessage) -> None:
+    if not self._connected or self._writer is None:
+        return
+    payload = json.dumps(message.to_dict()).encode("utf-8") + b"\n"
+    try:
+        self._writer.write(payload)
+        await self._writer.drain()
+    except (ConnectionError, OSError) as e:
+        logger.error(f"GSPro write failed: {e}")
+        self._on_connection_lost(e)
+```
+
+`expect_response` parameter is removed. The pre-send "clear stale buffer" block is removed (no other path reads the socket — the dedicated reader task owns it).
+
+**Reader loop.**
+
+```
+async def _reader_loop(self) -> None:
+    buffer = b""
+    while self._connected and self._reader is not None:
+        try:
+            chunk = await self._reader.read(4096)
+        except (ConnectionError, OSError) as e:
+            self._on_connection_lost(e)
+            return
+        if not chunk:                       # EOF — peer closed
+            self._on_connection_lost(None)
+            return
+        buffer += chunk
+        buffer = self._drain_buffer(buffer)
+```
+
+`_drain_buffer` extracts complete JSON objects from `buffer`:
+
+1. Split on `\n` first (handles the common, line-terminated case).
+2. For any line that fails to parse, attempt `JSONDecoder().raw_decode` over the accumulated buffer (handles the rare batched case, matches `GSPRO_TCP_PROTOCOL.md` §2).
+3. Special case: a non-JSON line containing `"GSPro ready"` is synthesized into `{"Code": 202, "Message": "GSPro ready"}` (matches the GsProApi.cs handshake handling in its ReadLoop, lines 564–567).
+4. Each successfully extracted object is passed to `_handle_response` (existing function — unchanged).
+5. Returns any unparsed tail to be retained for the next read.
+
+**Connection-lost path.** `_on_connection_lost(exc)`:
+
+- Marks `self._connected = False`.
+- Stops the heartbeat task (`_stop_heartbeat_timer`).
+- Schedules `self._writer.close()` and discards `self._reader`.
+- Notifies disconnect callbacks (`_notify_disconnect`). `GSProConnectionManager` listens for this and starts `ReconnectionManager.attempt_reconnect(self._client.connect)`.
+
+**Disconnect.** `async def disconnect(self) -> None`:
+
+1. Stop heartbeat task.
+2. Stop reader task.
+3. If still connected, send a shutdown heartbeat (`LaunchMonitorIsReady=False, IsHeartBeat=True`) and `await writer.drain()`.
+4. `await asyncio.sleep(0.250)`.
+5. `writer.close(); await writer.wait_closed()`.
+6. Clear `_shot_number`, `_current_player`, `_connected = False`.
+
+**Removed surface:** `connect_async`, `disconnect_async`, `send_shot_async`, `send_status_async`. The async methods *are* the API now.
+
+**Heartbeat task.** No change in concept — `_heartbeat_loop` already does `await asyncio.sleep(...)` and calls `send_heartbeat`. With `send_heartbeat` now native async, the loop becomes:
+
+```
+async def _heartbeat_loop(self) -> None:
+    while self._connected and self._match_started:
+        await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+        if self._connected and self._match_started:
+            await self.send_heartbeat()
+```
+
+`set_hardware_ready` and `_on_match_started` currently call `self.send_heartbeat()` directly. With `send_heartbeat` async, those sync call sites become:
+
+```
+asyncio.create_task(self.send_heartbeat())
+```
+
+This is fire-and-forget and matches the prior behavior (those callers didn't use the return value).
+
+### 3. Keepalive and reconnection
+
+**`_configure_socket(sock)`** in `GSProClient`:
+
+```
+sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+sock.setsockopt(socket.SOL_SOCKET,  socket.SO_KEEPALIVE, 1)
+if sys.platform == "darwin":
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, 30)
+elif sys.platform.startswith("linux"):
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE,  30)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
+    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT,    3)
+```
+
+`TCP_KEEPALIVE` is the macOS spelling; the Linux constants only exist on Linux. Guard with `hasattr(socket, "TCP_KEEPIDLE")` etc. to keep import-time safe across platforms.
+
+**`ReconnectionManager` changes** (in `src/gc2_connect/utils/reconnect.py`):
+
+- `max_retries: int | None = None` — `None` means infinite retries.
+- The bounded-exit branch (`while attempt < self.max_retries ...`) becomes `while (self.max_retries is None or attempt < self.max_retries) and not self._cancelled`.
+- The "after max attempts" log line and `FAILED` state only fire when `max_retries` is a positive int.
+- `cancel()` semantics unchanged. The UI calls it via the existing Disconnect action.
+
+**Defaults for GSPro** (in `services/connection_manager.py::GSProConnectionManager`):
+
+```
+self._reconnect_mgr = ReconnectionManager(
+    max_retries=None,   # infinite
+    base_delay=5.0,
+    max_delay=60.0,
+)
+```
+
+USB-side `ReconnectionManager` instantiation is **not** touched in this change.
+
+### 4. API ripple
+
+| Caller | Change |
+|---|---|
+| `services/connection_manager.py::GSProConnectionManager.send_status` | becomes `async def`; awaits `self._client.send_status(status)` |
+| `services/connection_manager.py::GSProConnectionManager.send_shot` | already async; swap `send_shot_async` → `send_shot` |
+| `services/shot_router.py:164` | swap `send_shot_async` → `send_shot` |
+| `ui/app.py:~994` | `self._gspro_mgr.send_status(status)` → `await self._gspro_mgr.send_status(status)` (caller is already async) |
+| `tests/conftest.py::gspro_client` | becomes `async def` with `@pytest.fixture` (pytest-asyncio is already configured `asyncio_mode = "auto"`); awaits `client.connect()` / `client.disconnect()` |
+| `tests/unit/test_gspro_heartbeat.py` | tests that `patch.object(client, "send_heartbeat")` use `AsyncMock`; those tests become `async def` |
+
+### 5. Tests
+
+**Existing tests:** updated as above to track the API shape change.
+
+**New tests (TDD — write before implementing the corresponding code):**
+
+- `test_reconnect_manager_supports_infinite_retries` — `max_retries=None` does not exit on attempt count; only `cancel()` ends the loop.
+- `test_gspro_client_appends_newline_to_writes` — `MockGSProServer` records raw bytes; assert each captured message ends with `\n`.
+- `test_gspro_client_enables_keepalive` — after `await client.connect()`, the underlying socket has `SO_KEEPALIVE == 1`.
+- `test_gspro_client_reader_loop_handles_dropped_connection` — mock server abruptly closes; client transitions to disconnected and fires disconnect callback.
+- `test_send_shot_returns_none_and_acks_via_callback` — `send_shot` returns `None`; the `Code:200` ack arrives via the existing response callback.
+- `test_gspro_client_reconnects_forever_with_capped_backoff` — instrument `ReconnectionManager.get_delay_for_attempt` returns `5, 10, 20, 40, 60, 60, …`.
+- `test_gspro_client_handshakes_with_bare_gspro_ready` — mock server sends the bare string `"GSPro ready\n"` (not JSON); client treats as `Code:202`, fires match-started callback.
+
+**Manual end-to-end smoke** (after code merges green):
+
+1. Start `tools/mock_gspro_server.py`.
+2. Run the app, connect, fire a few shots.
+3. Kill the mock server mid-session.
+4. Confirm the client transitions to Reconnecting and keeps trying past the previous 31s cap.
+5. Restart the mock server; confirm reconnect succeeds and shots resume.
+
+## Files changed
+
+| Path | Change |
+|---|---|
+| `src/gc2_connect/gspro/client.py` | Async rewrite; newline framing; keepalive; reader loop via StreamReader; sync wrappers removed; `_send_message` no longer returns ack. |
+| `src/gc2_connect/utils/reconnect.py` | `max_retries: int \| None = None`; loop condition + state transitions handle the infinite case. |
+| `src/gc2_connect/services/connection_manager.py` | GSPro `ReconnectionManager` defaults: `max_retries=None, base_delay=5.0, max_delay=60.0`. `send_status` becomes async. Internal calls to `send_shot_async` swap to `send_shot`. |
+| `src/gc2_connect/services/shot_router.py` | `send_shot_async` → `send_shot`. |
+| `src/gc2_connect/ui/app.py` | One call site awaits `send_status`. |
+| `tests/conftest.py` | `gspro_client` fixture becomes `async def @pytest.fixture` (pytest-asyncio auto mode is already configured). |
+| `tests/unit/test_gspro_heartbeat.py` | `AsyncMock` for `send_heartbeat` patches; affected tests `async def`. |
+| `docs/GSPRO_TCP_PROTOCOL.md` | Already rewritten in this change to reflect real GSPro v1.x wire. |
+
+No new files.
+
+## Execution order
+
+1. **`ReconnectionManager` infinite retries.** Write `test_reconnect_manager_supports_infinite_retries`. Make it pass. Smallest blast radius; nothing depends on it yet.
+2. **`GSProClient` async migration** — single atomic change. Write the new failing tests (`appends_newline`, `enables_keepalive`, `reader_loop_handles_dropped`, `send_shot_returns_none_and_acks_via_callback`, `handshakes_with_bare_gspro_ready`). Then rewrite `client.py`. Update `conftest.py` and `test_gspro_heartbeat.py` AsyncMock patches in the same change so the suite stays green.
+3. **Ripple to callers.** Update `connection_manager.py` (including `send_status` async + reconnect defaults), `shot_router.py`, `app.py`. Add `test_gspro_client_reconnects_forever_with_capped_backoff`.
+4. **Local CI gate.** `uv run pytest && uv run mypy src/ && uv run ruff check . && uv run ruff format --check .`
+5. **Manual smoke test** with `tools/mock_gspro_server.py` (steps in §5 above).
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `MockGSProServer` expects sync-style framing | Verify the mock server's parser handles `\n`-terminated input (likely already does); add a test that feeds it `\n`-framed input explicitly. |
+| Async-conversion regression on a hot path (shot ack timing) | The Code:200 ack already flows through `_handle_response` in the existing reader loop; this design just removes the redundant inline read in `_send_message`. The async path is what GsProApi.cs reference uses today. |
+| Linux constants (`TCP_KEEPIDLE` etc.) missing on some Pythons | Guard each `setsockopt` with `hasattr(socket, "...")`. |
+| `_on_match_started` / `set_hardware_ready` currently call `send_heartbeat` synchronously from sync contexts | Replace with `asyncio.create_task(self.send_heartbeat())`. Guarded by the existing "no running loop" handling pattern in `_start_heartbeat_timer`. |
+| User pressing Disconnect mid-Reconnect needs to actually stop the loop | `ReconnectionManager.cancel()` already wired; verify the Disconnect action in the UI calls it on the GSPro manager. |
+
+## Open questions
+
+None at design time. All design decisions confirmed in brainstorming session 2026-05-11.

--- a/src/gc2_connect/gspro/client.py
+++ b/src/gc2_connect/gspro/client.py
@@ -1,6 +1,6 @@
 # ABOUTME: TCP client for GSPro Open Connect API v1.
 # ABOUTME: Sends shot data to GSPro golf simulator and handles responses.
-"""GSPro Open Connect API v1 client."""
+"""GSPro Open Connect API v1 client (async)."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import asyncio
 import json
 import logging
 import socket
-import time
+import sys
 from collections.abc import Callable
 from typing import Any
 
@@ -35,18 +35,25 @@ def _notify_callbacks(callbacks: list[Callable[..., None]], *args: Any) -> None:
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 921
 HEARTBEAT_INTERVAL_SECONDS = 6.0
+CONNECT_TIMEOUT_SECONDS = 5.0
+SHUTDOWN_GRACE_SECONDS = 0.250
+KEEPALIVE_IDLE_SECONDS = 30
+KEEPALIVE_INTVL_SECONDS = 10
+KEEPALIVE_CNT = 3
 
 
 class GSProClient:
-    """Client for GSPro Open Connect API v1."""
+    """Async client for GSPro Open Connect API v1."""
 
     def __init__(self, host: str = DEFAULT_HOST, port: int = DEFAULT_PORT):
         self.host = host
         self.port = port
-        self._socket: socket.socket | None = None
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
         self._connected = False
         self._shot_number = 0
         self._current_player: dict[str, Any] | None = None
+
         self._response_callbacks: list[Callable[[GSProResponse], None]] = []
         self._disconnect_callbacks: list[Callable[[], None]] = []
 
@@ -55,14 +62,12 @@ class GSProClient:
         self._match_started_callbacks: list[Callable[[], None]] = []
         self._match_ended_callbacks: list[Callable[[], None]] = []
 
-        # Reader loop state
         self._reader_task: asyncio.Task[None] | None = None
-        self._reader_running = False
+        self._heartbeat_task: asyncio.Task[None] | None = None
 
         # Match state tracking for heartbeat logic
         self._match_started = False
         self._hardware_ready = False
-        self._heartbeat_task: asyncio.Task[None] | None = None
 
         # Register internal handlers for match state changes
         self._match_started_callbacks.append(self._on_match_started)
@@ -105,11 +110,20 @@ class GSProClient:
 
         Called when GC2 status changes (FLAGS in 0M message).
         """
-        if self._hardware_ready != ready:
-            self._hardware_ready = ready
-            # Send status update if match is active
-            if self._match_started:
-                self.send_heartbeat()
+        if self._hardware_ready == ready:
+            return
+        self._hardware_ready = ready
+        # Send status update if match is active
+        if not self._match_started:
+            return
+        self._schedule_heartbeat()
+
+    def _schedule_heartbeat(self) -> None:
+        """Fire-and-forget a heartbeat from a sync context."""
+        try:
+            asyncio.create_task(self.send_heartbeat())
+        except RuntimeError:
+            logger.debug("No running loop; skipping heartbeat schedule")
 
     def add_response_callback(self, callback: Callable[[GSProResponse], None]) -> None:
         """Add a callback for GSPro responses."""
@@ -176,10 +190,11 @@ class GSProClient:
 
         Starts the heartbeat timer and sends current ready status.
         """
-        if not self._match_started:
-            self._match_started = True
-            self._start_heartbeat_timer()
-            self.send_heartbeat()
+        if self._match_started:
+            return
+        self._match_started = True
+        self._start_heartbeat_timer()
+        self._schedule_heartbeat()
 
     def _on_match_ended(self) -> None:
         """Handle match ended event (code 203).
@@ -187,9 +202,10 @@ class GSProClient:
         Stops the heartbeat timer. Does not send "not ready" here;
         the disconnect sequence handles the final "not ready" message.
         """
-        if self._match_started:
-            self._match_started = False
-            self._stop_heartbeat_timer()
+        if not self._match_started:
+            return
+        self._match_started = False
+        self._stop_heartbeat_timer()
 
     def _start_heartbeat_timer(self) -> None:
         """Start periodic heartbeat timer."""
@@ -203,21 +219,298 @@ class GSProClient:
 
     def _stop_heartbeat_timer(self) -> None:
         """Stop the heartbeat timer."""
-        if self._heartbeat_task:
+        if self._heartbeat_task is not None:
             self._heartbeat_task.cancel()
             self._heartbeat_task = None
             logger.info("GSPro heartbeat timer stopped")
 
     async def _heartbeat_loop(self) -> None:
         """Send heartbeats at regular intervals while match is active."""
-        while self._connected and self._match_started:
-            await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
-            if self._connected and self._match_started:
-                self.send_heartbeat()
+        try:
+            while self._connected and self._match_started:
+                await asyncio.sleep(HEARTBEAT_INTERVAL_SECONDS)
+                if self._connected and self._match_started:
+                    await self.send_heartbeat()
+        except asyncio.CancelledError:
+            pass
+
+    # -------------------------------------------------------------------------
+    # Socket configuration
+    # -------------------------------------------------------------------------
+
+    def _configure_socket(self, sock: socket.socket) -> None:
+        """Configure socket options for TCP_NODELAY and SO_KEEPALIVE."""
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        if sys.platform == "darwin" and hasattr(socket, "TCP_KEEPALIVE"):
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPALIVE, KEEPALIVE_IDLE_SECONDS)
+        elif sys.platform.startswith("linux"):
+            if hasattr(socket, "TCP_KEEPIDLE"):
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, KEEPALIVE_IDLE_SECONDS)
+            if hasattr(socket, "TCP_KEEPINTVL"):
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, KEEPALIVE_INTVL_SECONDS)
+            if hasattr(socket, "TCP_KEEPCNT"):
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, KEEPALIVE_CNT)
+
+    # -------------------------------------------------------------------------
+    # Connection management
+    # -------------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to GSPro."""
+        try:
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port),
+                timeout=CONNECT_TIMEOUT_SECONDS,
+            )
+        except (TimeoutError, asyncio.TimeoutError, OSError) as e:
+            logger.error(f"Failed to connect to GSPro: {e}")
+            self._reader = None
+            self._writer = None
+            self._connected = False
+            return False
+
+        assert self._writer is not None
+        sock = self._writer.get_extra_info("socket")
+        if sock is not None:
+            self._configure_socket(sock)
+
+        self._connected = True
+        logger.info(f"Connected to GSPro at {self.host}:{self.port}")
+
+        # Send initial heartbeat to register with GSPro
+        logger.info("Sending initial heartbeat to GSPro...")
+        await self.send_heartbeat()
+        logger.info("Initial heartbeat sent")
+
+        # Start background reader loop for unsolicited GSPro messages
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        return True
+
+    async def disconnect(self) -> None:
+        """Cleanly disconnect from GSPro.
+
+        Following OpenSkyPlus2 reference implementation:
+        1. Stop heartbeat timer (stop sending heartbeats)
+        2. Cancel reader task
+        3. Send heartbeat with LaunchMonitorIsReady=false
+        4. Wait 250ms for GSPro to process
+        5. Close writer
+        """
+        if self._writer is None and not self._connected:
+            return
+
+        # Step 1: Stop the heartbeat timer
+        self._stop_heartbeat_timer()
+        self._match_started = False
+
+        # Step 2: Cancel the reader task
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            self._reader_task = None
+
+        # Step 3: Tell GSPro we're going offline
+        if self._writer is not None and self._connected:
+            try:
+                await self._send_shutdown_heartbeat()
+                await asyncio.sleep(SHUTDOWN_GRACE_SECONDS)
+            except Exception as e:
+                logger.debug(f"Error sending shutdown heartbeat: {e}")
+
+        # Step 4: Close the writer
+        if self._writer is not None:
+            try:
+                self._writer.close()
+                await self._writer.wait_closed()
+            except Exception:
+                pass
+
+        # Step 5: Clear internal state
+        self._reader = None
+        self._writer = None
+        self._connected = False
+        self._shot_number = 0
+        self._current_player = None
+        logger.info("Disconnected from GSPro (clean shutdown)")
+
+    async def _send_shutdown_heartbeat(self) -> None:
+        """Send final heartbeat indicating launch monitor is going offline.
+
+        This tells GSPro the launch monitor is going offline gracefully.
+        """
+        if self._writer is None:
+            return
+
+        message = GSProShotMessage(
+            ShotNumber=self._shot_number,
+            ShotDataOptions=GSProShotOptions(
+                ContainsBallData=False,
+                ContainsClubData=False,
+                LaunchMonitorIsReady=False,  # Key: telling GSPro we're going offline
+                IsHeartBeat=True,
+            ),
+        )
+        payload = json.dumps(message.to_dict()).encode("utf-8") + b"\n"
+        self._writer.write(payload)
+        await self._writer.drain()
+        logger.debug("Sent shutdown heartbeat (LaunchMonitorIsReady=false)")
+
+    # -------------------------------------------------------------------------
+    # Send methods
+    # -------------------------------------------------------------------------
+
+    async def send_shot(self, shot: GC2ShotData) -> None:
+        """Send a shot to GSPro.
+
+        The GSPro ack arrives asynchronously via the reader loop's response callbacks.
+        """
+        if not self._connected or self._writer is None:
+            logger.error("Not connected to GSPro")
+            return
+        self._shot_number += 1
+        message = GSProShotMessage.from_gc2_shot(shot, self._shot_number)
+        await self._send_message(message)
+
+    async def send_heartbeat(self) -> None:
+        """Send a heartbeat to GSPro.
+
+        Uses is_ready_to_report to determine LaunchMonitorIsReady value.
+        This is true only when both GC2 hardware is ready AND match is active.
+        """
+        if not self._connected or self._writer is None:
+            return
+
+        message = GSProShotMessage(
+            ShotNumber=self._shot_number,
+            ShotDataOptions=GSProShotOptions(
+                ContainsBallData=False,
+                ContainsClubData=False,
+                LaunchMonitorIsReady=self.is_ready_to_report,
+                IsHeartBeat=True,
+            ),
+        )
+        await self._send_message(message)
+
+    async def send_status(self, status: GC2BallStatus) -> None:
+        """Send ball status update to GSPro.
+
+        This sends a non-shot message to GSPro indicating:
+        - Whether the launch monitor is ready (green light)
+        - Whether a ball is detected
+        """
+        if not self._connected or self._writer is None:
+            return
+
+        message = GSProShotMessage(
+            ShotNumber=self._shot_number,
+            ShotDataOptions=GSProShotOptions(
+                ContainsBallData=False,
+                ContainsClubData=False,
+                LaunchMonitorIsReady=status.is_ready,
+                LaunchMonitorBallDetected=status.ball_detected,
+                IsHeartBeat=False,
+            ),
+        )
+        logger.debug(
+            f"Sending status: ready={status.is_ready}, ball_detected={status.ball_detected}"
+        )
+        await self._send_message(message)
+
+    async def _send_message(self, message: GSProShotMessage) -> None:
+        """Send a message with newline framing.
+
+        Appends \\n to every outbound JSON write, matching the GsProApi.cs reference.
+        """
+        if self._writer is None:
+            logger.error("Cannot send message: writer is None")
+            return
+        payload = json.dumps(message.to_dict()).encode("utf-8") + b"\n"
+        try:
+            self._writer.write(payload)
+            await self._writer.drain()
+            logger.debug(f"Sent {len(payload)} bytes: {payload[:200]!r}")
+        except (ConnectionError, OSError) as e:
+            logger.error(f"GSPro write failed: {e}")
+            self._on_connection_lost()
 
     # -------------------------------------------------------------------------
     # Reader loop for receiving unsolicited GSPro messages
     # -------------------------------------------------------------------------
+
+    async def _reader_loop(self) -> None:
+        """Background task that continuously reads from GSPro stream.
+
+        Handles unsolicited messages from GSPro such as:
+        - Code 201: Player info updates
+        - Code 202: Match started
+        - Code 203: Match ended
+        - Bare "GSPro ready" string (treated as code 202)
+        """
+        logger.debug("GSPro reader loop started")
+        buffer = b""
+        try:
+            while self._connected and self._reader is not None:
+                try:
+                    chunk = await self._reader.read(4096)
+                except (ConnectionError, OSError) as e:
+                    logger.warning(f"GSPro reader socket error: {e}")
+                    self._on_connection_lost()
+                    return
+                if not chunk:
+                    logger.warning("GSPro connection closed (EOF)")
+                    self._on_connection_lost()
+                    return
+                buffer = self._drain_buffer(buffer + chunk)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            logger.info("GSPro reader loop ended")
+
+    def _drain_buffer(self, buffer: bytes) -> bytes:
+        """Parse and dispatch complete JSON objects from the buffer.
+
+        Returns any remaining unparsed bytes.
+        """
+        text = buffer.decode("utf-8", errors="replace")
+        decoder = json.JSONDecoder()
+
+        while text:
+            stripped = text.lstrip()
+            if not stripped:
+                return b""
+            text = stripped
+
+            if text.startswith("GSPro ready"):
+                self._handle_response({"Code": 202, "Message": "GSPro ready"})
+                newline = text.find("\n")
+                if newline == -1:
+                    return b""
+                text = text[newline + 1 :]
+                continue
+
+            try:
+                obj, end = decoder.raw_decode(text)
+            except json.JSONDecodeError:
+                return text.encode("utf-8")
+
+            self._handle_response(obj)
+            text = text[end:]
+
+        return b""
+
+    def _on_connection_lost(self) -> None:
+        """Handle unexpected connection loss."""
+        if not self._connected:
+            return
+        self._connected = False
+        self._stop_heartbeat_timer()
+        self._match_started = False
+        if self._writer is not None:
+            try:
+                self._writer.close()
+            except Exception:
+                pass
+        self._notify_disconnect()
 
     def _handle_response(self, response_json: dict[str, Any]) -> None:
         """Handle a response from GSPro based on code.
@@ -245,339 +538,11 @@ class GSProClient:
                 logger.info("GSPro match ended (code 203)")
                 _notify_callbacks(self._match_ended_callbacks)
 
-    async def _reader_loop(self) -> None:
-        """Background task that continuously reads from GSPro socket.
+        response = GSProResponse.from_dict(response_json)
 
-        This loop handles unsolicited messages from GSPro such as:
-        - Code 201: Player info updates
-        - Code 202: Match started
-        - Code 203: Match ended
-        """
-        buffer = ""
-        logger.debug("GSPro reader loop started")
+        # Update player info if received
+        if response.Code == 201 and response.Player:
+            self._current_player = response.Player
+            logger.info(f"Player info: {response.Player}")
 
-        while self._reader_running and self._connected and self._socket:
-            try:
-                # Set socket to non-blocking for async reads
-                self._socket.setblocking(False)
-                try:
-                    data = self._socket.recv(4096)
-                    if not data:
-                        # Connection closed
-                        logger.warning("GSPro connection closed (empty recv)")
-                        break
-                    buffer += data.decode("utf-8")
-
-                    # Try to parse complete JSON objects
-                    while buffer:
-                        try:
-                            decoder = json.JSONDecoder()
-                            response_json, idx = decoder.raw_decode(buffer)
-                            buffer = buffer[idx:].lstrip()
-                            self._handle_response(response_json)
-                        except json.JSONDecodeError:
-                            # Incomplete JSON, wait for more data
-                            break
-
-                except BlockingIOError:
-                    # No data available, wait a bit
-                    await asyncio.sleep(0.1)
-                finally:
-                    if self._socket:
-                        self._socket.setblocking(True)
-
-            except OSError as e:
-                logger.error(f"Reader loop socket error: {e}")
-                break
-            except Exception as e:
-                logger.error(f"Reader loop error: {e}")
-                break
-
-        logger.info("GSPro reader loop ended")
-
-    def _start_reader_loop(self) -> None:
-        """Start the background reader loop.
-
-        This attempts to create an async task for the reader loop. If no event
-        loop is running (e.g., in synchronous-only contexts or tests), it will
-        log a debug message and skip starting the reader.
-        """
-        if self._reader_task is not None and not self._reader_task.done():
-            return  # Already running
-
-        try:
-            self._reader_running = True
-            self._reader_task = asyncio.create_task(self._reader_loop())
-            logger.debug("Started GSPro reader loop task")
-        except RuntimeError as e:
-            # No running event loop - this happens in sync-only contexts
-            logger.debug(f"Could not start reader loop (no event loop): {e}")
-            self._reader_running = False
-
-    def _stop_reader_loop(self) -> None:
-        """Stop the background reader loop."""
-        self._reader_running = False
-        if self._reader_task:
-            self._reader_task.cancel()
-            self._reader_task = None
-            logger.debug("Stopped GSPro reader loop task")
-
-    # -------------------------------------------------------------------------
-    # Connection management
-    # -------------------------------------------------------------------------
-
-    def connect(self) -> bool:
-        """Connect to GSPro."""
-        try:
-            # Use create_connection for cleaner connection handling
-            self._socket = socket.create_connection((self.host, self.port), timeout=5.0)
-            # Set TCP_NODELAY to disable Nagle's algorithm for immediate sends
-            self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-            self._socket.settimeout(5.0)
-            self._connected = True
-            logger.info(f"Connected to GSPro at {self.host}:{self.port}")
-
-            # Send initial heartbeat to register with GSPro
-            # Note: GSPro doesn't respond to heartbeats, so we just send it
-            logger.info("Sending initial heartbeat to GSPro...")
-            self.send_heartbeat()
-            logger.info("Initial heartbeat sent")
-
-            # Start background reader loop for unsolicited GSPro messages
-            self._start_reader_loop()
-
-            return True
-        except OSError as e:
-            logger.error(f"Failed to connect to GSPro: {e}")
-            self._socket = None
-            self._connected = False
-            return False
-
-    def disconnect(self) -> None:
-        """Cleanly disconnect from GSPro.
-
-        Following OpenSkyPlus2 reference implementation:
-        1. Stop heartbeat timer (stop sending heartbeats)
-        2. Stop reader loop (prevent any more reads)
-        3. Send heartbeat with LaunchMonitorIsReady=false
-        4. Wait 250ms for GSPro to process
-        5. Close socket
-
-        This tells GSPro the launch monitor is going offline gracefully
-        instead of just disappearing. TCP_NODELAY ensures the heartbeat
-        is sent immediately without buffering.
-        """
-        if not self._socket:
-            self._connected = False
-            return
-
-        # Step 1: Stop the heartbeat timer
-        self._stop_heartbeat_timer()
-        self._match_started = False
-
-        # Step 2: Stop the reader loop
-        self._stop_reader_loop()
-
-        # Step 3: Tell GSPro we're going offline
-        try:
-            self._send_shutdown_heartbeat()
-        except Exception as e:
-            logger.debug(f"Error sending shutdown heartbeat: {e}")
-
-        # Step 4: Wait for GSPro to process the heartbeat
-        time.sleep(0.250)
-
-        # Step 5: Close socket
-        try:
-            self._socket.close()
-        except Exception:
-            pass
-
-        # Step 6: Clear internal state
-        self._socket = None
-        self._connected = False
-        self._shot_number = 0
-        self._current_player = None
-        logger.info("Disconnected from GSPro (clean shutdown)")
-
-    def _send_shutdown_heartbeat(self) -> None:
-        """Send final heartbeat indicating launch monitor is going offline.
-
-        This is sent without waiting for a response since GSPro doesn't
-        respond to heartbeats anyway.
-        """
-        if not self._socket:
-            return
-
-        message = GSProShotMessage(
-            ShotNumber=self._shot_number,
-            ShotDataOptions=GSProShotOptions(
-                ContainsBallData=False,
-                ContainsClubData=False,
-                LaunchMonitorIsReady=False,  # Key: telling GSPro we're going offline
-                IsHeartBeat=True,
-            ),
-        )
-        json_data = json.dumps(message.to_dict())
-        self._socket.sendall(json_data.encode("utf-8"))
-        logger.debug("Sent shutdown heartbeat (LaunchMonitorIsReady=false)")
-
-    async def disconnect_async(self) -> None:
-        """Async version of disconnect for use in async contexts."""
-        await asyncio.get_event_loop().run_in_executor(None, self.disconnect)
-
-    async def connect_async(self) -> bool:
-        """Async version of connect."""
-        return await asyncio.get_event_loop().run_in_executor(None, self.connect)
-
-    def send_shot(self, shot: GC2ShotData) -> GSProResponse | None:
-        """Send a shot to GSPro."""
-        if not self._connected or not self._socket:
-            logger.error("Not connected to GSPro")
-            return None
-
-        self._shot_number += 1
-        message = GSProShotMessage.from_gc2_shot(shot, self._shot_number)
-
-        return self._send_message(message)
-
-    def send_heartbeat(self) -> GSProResponse | None:
-        """Send a heartbeat to GSPro.
-
-        Uses is_ready_to_report to determine LaunchMonitorIsReady value.
-        This is true only when both GC2 hardware is ready AND match is active.
-
-        Note: GSPro doesn't respond to heartbeat messages, so we don't wait for a response.
-        """
-        if not self._connected or not self._socket:
-            return None
-
-        message = GSProShotMessage(
-            ShotNumber=self._shot_number,
-            ShotDataOptions=GSProShotOptions(
-                ContainsBallData=False,
-                ContainsClubData=False,
-                LaunchMonitorIsReady=self.is_ready_to_report,
-                IsHeartBeat=True,
-            ),
-        )
-
-        return self._send_message(message, expect_response=False)
-
-    def send_status(self, status: GC2BallStatus) -> GSProResponse | None:
-        """Send ball status update to GSPro.
-
-        This sends a non-shot message to GSPro indicating:
-        - Whether the launch monitor is ready (green light)
-        - Whether a ball is detected
-
-        This helps GSPro know when to expect shot data.
-
-        Note: GSPro doesn't respond to status messages, so we don't wait for a response.
-        """
-        if not self._connected or not self._socket:
-            return None
-
-        message = GSProShotMessage(
-            ShotNumber=self._shot_number,
-            ShotDataOptions=GSProShotOptions(
-                ContainsBallData=False,
-                ContainsClubData=False,
-                LaunchMonitorIsReady=status.is_ready,
-                LaunchMonitorBallDetected=status.ball_detected,
-                IsHeartBeat=False,
-            ),
-        )
-
-        logger.debug(
-            f"Sending status: ready={status.is_ready}, ball_detected={status.ball_detected}"
-        )
-        return self._send_message(message, expect_response=False)
-
-    async def send_status_async(self, status: GC2BallStatus) -> GSProResponse | None:
-        """Async version of send_status."""
-        return await asyncio.get_event_loop().run_in_executor(None, self.send_status, status)
-
-    def _send_message(
-        self, message: GSProShotMessage, expect_response: bool = True
-    ) -> GSProResponse | None:
-        """Send a message and optionally receive response.
-
-        Args:
-            message: The message to send
-            expect_response: If True, wait for and parse response. If False, just send.
-        """
-        if self._socket is None:
-            logger.error("Cannot send message: socket is None")
-            return None
-
-        sock = self._socket  # Local reference for type narrowing
-
-        try:
-            # Clear any buffered data before sending (stale responses)
-            sock.setblocking(False)
-            try:
-                while True:
-                    stale = sock.recv(4096)
-                    if stale:
-                        logger.debug(f"Cleared {len(stale)} bytes of stale buffer data")
-                    else:
-                        break
-            except BlockingIOError:
-                pass  # No data to clear, good
-            finally:
-                sock.setblocking(True)
-
-            # Send JSON message
-            json_data = json.dumps(message.to_dict())
-            encoded = json_data.encode("utf-8")
-            sock.sendall(encoded)
-            logger.debug(f"Sent {len(encoded)} bytes: {json_data}")
-
-            if not expect_response:
-                return None
-
-            # Receive response
-            sock.settimeout(5.0)
-            logger.debug("Waiting for response...")
-            response_data = sock.recv(4096)
-
-            if not response_data:
-                logger.warning("Empty response from GSPro")
-                return None
-
-            response_str = response_data.decode("utf-8")
-
-            # Parse only the first JSON object (handle concatenated responses)
-            decoder = json.JSONDecoder()
-            response_json, _ = decoder.raw_decode(response_str)
-            response = GSProResponse.from_dict(response_json)
-
-            logger.debug(f"Received: {response_json}")
-
-            # Update player info if received
-            if response.Code == 201 and response.Player:
-                self._current_player = response.Player
-                logger.info(f"Player info: {response.Player}")
-
-            self._notify_response(response)
-            return response
-
-        except TimeoutError:
-            logger.warning("Timeout waiting for GSPro response")
-            return None
-        except OSError as e:
-            logger.error(f"Socket error: {e}")
-            was_connected = self._connected
-            self._connected = False
-            if was_connected:
-                logger.error("GSPro connection lost!")
-                self._notify_disconnect()
-            return None
-        except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON response: {e}")
-            return None
-
-    async def send_shot_async(self, shot: GC2ShotData) -> GSProResponse | None:
-        """Async version of send_shot."""
-        return await asyncio.get_event_loop().run_in_executor(None, self.send_shot, shot)
+        self._notify_response(response)

--- a/src/gc2_connect/services/connection_manager.py
+++ b/src/gc2_connect/services/connection_manager.py
@@ -63,7 +63,7 @@ def _prevent_app_nap(reason: str = "Processing GC2 shot data") -> None:
         return
 
     try:
-        from Foundation import NSProcessInfo  # type: ignore[import-untyped]
+        from Foundation import NSProcessInfo  # type: ignore
 
         # NSActivityUserInitiatedAllowingIdleSystemSleep = 0x00FFFFFF
         # This prevents App Nap but allows system sleep

--- a/src/gc2_connect/services/connection_manager.py
+++ b/src/gc2_connect/services/connection_manager.py
@@ -63,7 +63,7 @@ def _prevent_app_nap(reason: str = "Processing GC2 shot data") -> None:
         return
 
     try:
-        from Foundation import NSProcessInfo  # type: ignore[import-not-found]
+        from Foundation import NSProcessInfo  # type: ignore[import-untyped]
 
         # NSActivityUserInitiatedAllowingIdleSystemSleep = 0x00FFFFFF
         # This prevents App Nap but allows system sleep
@@ -266,8 +266,8 @@ class ShotForwarder:
             return False
 
         try:
-            response = await self._gspro_mgr.send_shot(shot)
-            logger.info(f"Shot #{shot.shot_id} forwarded to GSPro (response: {response})")
+            await self._gspro_mgr.send_shot(shot)
+            logger.info(f"Shot #{shot.shot_id} forwarded to GSPro")
             return True
         except Exception as e:
             logger.error(f"Failed to forward shot #{shot.shot_id} to GSPro: {e}")
@@ -486,7 +486,7 @@ class GSProConnectionManager:
             True if connection succeeded, False otherwise.
         """
         if self._client is not None:
-            self.disconnect()
+            await self.disconnect()
 
         self._host = host
         self._port = port
@@ -496,7 +496,7 @@ class GSProConnectionManager:
         # Restore shot number from our persistent storage
         self._client._shot_number = self._shot_number
 
-        success = await self._client.connect_async()
+        success = await self._client.connect()
         self._callback_registry.notify_gspro_connect(success)
 
         if success:
@@ -507,42 +507,40 @@ class GSProConnectionManager:
 
         return success
 
-    def disconnect(self) -> None:
+    async def disconnect(self) -> None:
         """Disconnect from GSPro."""
         if self._client is not None:
             # Save shot number before disconnect (client resets it)
             self._shot_number = self._client.shot_number
-            self._client.disconnect()
+            await self._client.disconnect()
             self._client = None
 
         logger.info("GSPro disconnected via connection manager")
 
-    async def send_shot(self, shot: GC2ShotData) -> Any:
+    async def send_shot(self, shot: GC2ShotData) -> None:
         """Send shot to GSPro.
+
+        The GSPro ack arrives asynchronously via response callbacks.
 
         Args:
             shot: The shot data to send.
-
-        Returns:
-            Response from GSPro, or None if not connected.
         """
         if self._client is None or not self._client.is_connected:
             logger.warning("Cannot send shot: GSPro not connected")
-            return None
+            return
 
-        response = await self._client.send_shot_async(shot)
+        await self._client.send_shot(shot)
         # Keep our shot number in sync
         self._shot_number = self._client.shot_number
-        return response
 
-    def send_status(self, status: GC2BallStatus) -> None:
+    async def send_status(self, status: GC2BallStatus) -> None:
         """Send ball status to GSPro.
 
         Args:
             status: The ball status to send.
         """
         if self._client is not None and self._client.is_connected:
-            self._client.send_status(status)
+            await self._client.send_status(status)
 
     def _on_disconnect(self) -> None:
         """Internal callback for disconnection from the client."""
@@ -614,7 +612,12 @@ def reset_all() -> None:
     if _gc2_manager is not None:
         _gc2_manager.disconnect()
     if _gspro_manager is not None:
-        _gspro_manager.disconnect()
+        # Schedule async disconnect on the running event loop, or best-effort skip
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_gspro_manager.disconnect())
+        except RuntimeError:
+            pass  # No running event loop; the manager will be GC'd
     if _shot_forwarder is not None:
         _shot_forwarder.disable()
 
@@ -635,6 +638,11 @@ def shutdown_all() -> None:
     if _gc2_manager is not None:
         _gc2_manager.disconnect()
     if _gspro_manager is not None:
-        _gspro_manager.disconnect()
+        # Schedule async disconnect on the running event loop, or best-effort skip
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(_gspro_manager.disconnect())
+        except RuntimeError:
+            pass  # No running event loop; skip graceful disconnect
 
     logger.info("All connections shut down")

--- a/src/gc2_connect/services/shot_router.py
+++ b/src/gc2_connect/services/shot_router.py
@@ -161,7 +161,7 @@ class ShotRouter:
             raise RuntimeError("GSPro client not configured")
 
         logger.debug(f"Routing shot {shot.shot_id} to GSPro")
-        await self._gspro_client.send_shot_async(shot)
+        await self._gspro_client.send_shot(shot)
 
     async def _route_to_open_range(self, shot: GC2ShotData) -> None:
         """Process shot in Open Range.

--- a/src/gc2_connect/ui/app.py
+++ b/src/gc2_connect/ui/app.py
@@ -330,7 +330,7 @@ class GC2ConnectApp:
     async def _reconnect_gspro(self) -> None:
         """Attempt to reconnect to GSPro."""
         # Disconnect existing connection via manager
-        self._gspro_mgr.disconnect()
+        await self._gspro_mgr.disconnect()
 
         # Get connection parameters
         host = self.gspro_host_input.value if self.gspro_host_input else self.settings.gspro.host
@@ -916,7 +916,7 @@ class GC2ConnectApp:
         self._shot_forwarder.disable()
 
         # Disconnect via manager
-        self._gspro_mgr.disconnect()
+        asyncio.create_task(self._gspro_mgr.disconnect())
 
         self.gspro_status_label.text = "Disconnected"
         self.gspro_status_label.classes(remove="text-green-500 text-yellow-500", add="text-red-500")
@@ -991,7 +991,7 @@ class GC2ConnectApp:
 
             # Send status to GSPro if connected (use manager)
             if self.send_status_to_gspro and self._gspro_mgr.is_connected:
-                self._gspro_mgr.send_status(status)
+                asyncio.create_task(self._gspro_mgr.send_status(status))
         except Exception as e:
             logger.error(f"Error handling status: {e}")
 

--- a/src/gc2_connect/ui/app.py
+++ b/src/gc2_connect/ui/app.py
@@ -140,7 +140,10 @@ class GC2ConnectApp:
 
         # Reconnection managers
         self._gc2_reconnect_mgr = ReconnectionManager(max_retries=5, base_delay=1.0)
-        self._gspro_reconnect_mgr = ReconnectionManager(max_retries=5, base_delay=1.0)
+        # GSPro retries forever (user cancels via Disconnect); 5s → 60s capped backoff.
+        self._gspro_reconnect_mgr = ReconnectionManager(
+            max_retries=None, base_delay=5.0, max_delay=60.0
+        )
         self._setup_reconnection_callbacks()
 
         # Tasks for reconnection

--- a/src/gc2_connect/utils/reconnect.py
+++ b/src/gc2_connect/utils/reconnect.py
@@ -40,14 +40,15 @@ class ReconnectionManager:
 
     def __init__(
         self,
-        max_retries: int = 5,
+        max_retries: int | None = 5,
         base_delay: float = 1.0,
         max_delay: float = 16.0,
     ) -> None:
         """Initialize the reconnection manager.
 
         Args:
-            max_retries: Maximum number of reconnection attempts
+            max_retries: Maximum number of reconnection attempts. ``None`` means
+                retry forever until ``cancel()`` is called.
             base_delay: Initial delay between retries in seconds
             max_delay: Maximum delay between retries in seconds
         """
@@ -143,8 +144,15 @@ class ReconnectionManager:
         self._retry_count = 0
         self._set_state(ReconnectionState.CONNECTING)
 
+        def _should_continue(attempt: int) -> bool:
+            if self._cancelled:
+                return False
+            if self.max_retries is None:
+                return True
+            return attempt < self.max_retries
+
         attempt = 0
-        while attempt < self.max_retries and not self._cancelled:
+        while _should_continue(attempt):
             try:
                 # Call connect function (handle both sync and async)
                 result = connect_fn()
@@ -161,17 +169,15 @@ class ReconnectionManager:
             except Exception as e:
                 logger.warning(f"Connection attempt {attempt + 1} failed: {e}")
 
-            # Failed - calculate delay and wait
             attempt += 1
             self._retry_count = attempt
 
-            if attempt < self.max_retries and not self._cancelled:
+            if _should_continue(attempt):
                 delay = self.get_delay_for_attempt(attempt - 1)
                 self._set_state(ReconnectionState.RECONNECTING)
                 self._notify_attempt(attempt, delay)
-                logger.info(
-                    f"Reconnection attempt {attempt}/{self.max_retries}, waiting {delay:.1f}s..."
-                )
+                max_str = "∞" if self.max_retries is None else str(self.max_retries)
+                logger.info(f"Reconnection attempt {attempt}/{max_str}, waiting {delay:.1f}s...")
 
                 try:
                     await asyncio.sleep(delay)
@@ -185,7 +191,7 @@ class ReconnectionManager:
             return False
 
         self._set_state(ReconnectionState.FAILED)
-        logger.error(f"Reconnection failed after {self.max_retries} attempts")
+        logger.error(f"Reconnection failed after {self._retry_count} attempts")
         return False
 
     def cancel(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # ABOUTME: Pytest configuration and shared fixtures for all tests.
 # ABOUTME: Contains fixtures for GC2 shot data, GSPro messages, and mock objects.
 
+import asyncio
 import json
 from typing import Any
 from unittest.mock import MagicMock
@@ -181,8 +182,8 @@ def gspro_error_response_dict() -> dict[str, Any]:
 
 
 @pytest.fixture
-def mock_gspro_server():
-    """Fixture that runs a mock GSPro server in a background thread.
+async def mock_gspro_server():
+    """Fixture that runs a mock GSPro server for testing.
 
     The server accepts shot data and returns success responses.
     Use `server.received_shots` to inspect what was received.
@@ -190,99 +191,59 @@ def mock_gspro_server():
     Yields:
         MockGSProServer instance with host, port, and received_shots attributes.
     """
-    import socket
-    import threading
-    from dataclasses import dataclass
-    from dataclasses import field as dataclass_field
+    from tests.simulators.gspro.config import MockGSProServerConfig, ResponseType
+    from tests.simulators.gspro.server import MockGSProServer
 
-    @dataclass
-    class MockGSProServer:
-        host: str
-        port: int
-        received_shots: list[dict[str, Any]] = dataclass_field(default_factory=list)
-        _server: socket.socket | None = None
-        _thread: threading.Thread | None = None
-        _running: bool = False
-        _conn: socket.socket | None = None
+    class _ServerAdapter:
+        """Adapter exposing received_shots as a list of raw dicts for test compatibility."""
 
-    def run_server(server: MockGSProServer) -> None:
-        """Run the mock GSPro server."""
-        server._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        server._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        server._server.settimeout(0.5)  # Allow checking _running flag
-        server._server.bind((server.host, server.port))
-        server._server.listen(1)
+        def __init__(self, server: MockGSProServer) -> None:
+            self._server = server
 
-        while server._running:
-            try:
-                conn, _addr = server._server.accept()
-                server._conn = conn
-                conn.settimeout(0.5)
+        @property
+        def host(self) -> str:
+            return self._server.host
 
-                while server._running:
-                    try:
-                        data = conn.recv(4096)
-                        if not data:
-                            break
+        @property
+        def port(self) -> int:
+            return self._server.port
 
-                        # Parse and store received shot
-                        try:
-                            message = json.loads(data.decode("utf-8"))
-                            server.received_shots.append(message)
+        @property
+        def received_shots(self) -> list[dict[str, Any]]:
+            """Return all received messages as raw dicts."""
+            return [s.raw_message for s in self._server.get_shots()]
 
-                            # Send success response with player info
-                            # Use Code 201 to include player info (per GSPro API)
-                            response = {
-                                "Code": 201,
-                                "Message": "Shot received with player info",
-                                "Player": {"Handed": "RH", "Club": "DR"},
-                            }
-                            conn.sendall(json.dumps(response).encode("utf-8"))
-                        except json.JSONDecodeError:
-                            pass
+    config = MockGSProServerConfig(
+        host="127.0.0.1",
+        port=0,
+        response_type=ResponseType.SUCCESS,
+    )
+    # Override the response to use Code 201 with player info (what tests expect)
+    server = MockGSProServer(config)
 
-                    except TimeoutError:
-                        continue
-                    except OSError:
-                        break
+    # Patch the response to send Code 201 instead of 200
+    import gc2_connect  # noqa: F401
 
-                conn.close()
-                server._conn = None
-
-            except TimeoutError:
-                continue
-            except OSError:
-                break
-
-        if server._server:
-            server._server.close()
-
-    # Find a free port
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        port = s.getsockname()[1]
-
-    server = MockGSProServer(host="127.0.0.1", port=port)
-    server._running = True
-    server._thread = threading.Thread(target=run_server, args=(server,), daemon=True)
-    server._thread.start()
-
-    # Give server time to start
-    import time
-
-    time.sleep(0.1)
-
-    yield server
-
-    # Cleanup
-    server._running = False
-    if server._conn:
+    async def _send_response_201(writer, _shot):  # type: ignore[no-untyped-def]
+        response = {
+            "Code": 201,
+            "Message": "Shot received with player info",
+            "Player": {"Handed": "RH", "Club": "DR"},
+        }
         try:
-            server._conn.close()
+            writer.write(json.dumps(response).encode("utf-8"))
+            await writer.drain()
         except Exception:
             pass
-    if server._thread:
-        server._thread.join(timeout=1.0)
+
+    server._send_response = _send_response_201  # type: ignore[method-assign]
+
+    await server.start()
+    adapter = _ServerAdapter(server)
+
+    yield adapter
+
+    await server.stop()
 
 
 @pytest.fixture
@@ -297,19 +258,18 @@ def mock_gc2_reader():
 
 
 @pytest.fixture
-def gspro_client(mock_gspro_server):
+async def gspro_client(mock_gspro_server):
     """Fixture providing a GSProClient connected to the mock server."""
-    import time
-
     from gc2_connect.gspro.client import GSProClient
 
     client = GSProClient(host=mock_gspro_server.host, port=mock_gspro_server.port)
-    connected = client.connect()
+    connected = await client.connect()
     assert connected, "Failed to connect to mock GSPro server"
 
-    # Wait for heartbeat to be processed by server
-    time.sleep(0.1)
+    await asyncio.sleep(0.05)
 
-    yield client
-    if client.is_connected:
-        client.disconnect()
+    try:
+        yield client
+    finally:
+        if client.is_connected:
+            await client.disconnect()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -83,6 +83,8 @@ def _run_e2e_server(server: E2EMockGSProServer) -> None:
     server._server.bind((server.host, server.port))
     server._server.listen(1)
 
+    decoder = json.JSONDecoder()
+
     while server._running:
         try:
             conn, _addr = server._server.accept()
@@ -90,17 +92,33 @@ def _run_e2e_server(server: E2EMockGSProServer) -> None:
             conn.settimeout(0.5)
 
             shot_count = 0
-            while server._running:
+            text_buffer = ""
+            disconnected = False
+            while server._running and not disconnected:
                 try:
                     data = conn.recv(4096)
                     if not data:
                         break
 
-                    try:
-                        message = json.loads(data.decode("utf-8"))
+                    text_buffer += data.decode("utf-8", errors="replace")
+
+                    # Drain every complete JSON object from the buffer. The
+                    # client may send multiple newline-terminated objects in
+                    # one TCP packet, so a single json.loads is insufficient.
+                    while text_buffer:
+                        stripped = text_buffer.lstrip()
+                        if not stripped:
+                            text_buffer = ""
+                            break
+                        text_buffer = stripped
+                        try:
+                            message, end = decoder.raw_decode(text_buffer)
+                        except json.JSONDecodeError:
+                            break  # incomplete; wait for more bytes
+                        text_buffer = text_buffer[end:]
+
                         server.received_shots.append(message)
 
-                        # Check for disconnect trigger
                         if not message.get("ShotDataOptions", {}).get("IsHeartBeat", False):
                             shot_count += 1
                             if (
@@ -108,9 +126,9 @@ def _run_e2e_server(server: E2EMockGSProServer) -> None:
                                 and shot_count >= server.disconnect_after
                             ):
                                 conn.close()
+                                disconnected = True
                                 break
 
-                        # Send response
                         if server.error_mode:
                             response = {"Code": 500, "Message": "Internal error"}
                         else:
@@ -119,17 +137,17 @@ def _run_e2e_server(server: E2EMockGSProServer) -> None:
                                 "Message": "Shot received",
                                 "Player": {"Handed": "RH", "Club": "DR"},
                             }
-                        conn.sendall(json.dumps(response).encode("utf-8"))
-
-                    except json.JSONDecodeError:
-                        pass
+                        conn.sendall(json.dumps(response).encode("utf-8") + b"\n")
 
                 except TimeoutError:
                     continue
                 except OSError:
                     break
 
-            conn.close()
+            try:
+                conn.close()
+            except OSError:
+                pass
             server._conn = None
 
         except TimeoutError:

--- a/tests/e2e/test_error_handling.py
+++ b/tests/e2e/test_error_handling.py
@@ -123,7 +123,7 @@ class TestGSProConnectionErrors:
 
         # This will timeout trying to connect
         # Set a short timeout to speed up test
-        with patch.object(GSProClient, "connect_async") as mock_connect:
+        with patch.object(GSProClient, "connect") as mock_connect:
             mock_connect.return_value = False
             await app._connect_gspro()
 
@@ -173,8 +173,11 @@ class TestGSProConnectionErrors:
         await app._connect_gspro()
         assert app.gspro_client is not None
 
-        # Disconnect
+        # Disconnect (schedules async task via create_task)
         app._disconnect_gspro()
+
+        # Allow the scheduled disconnect task to complete (includes 0.25s grace period)
+        await asyncio.sleep(0.5)
 
         # Should be cleaned up
         assert app.gspro_client is None
@@ -348,8 +351,11 @@ class TestRecoveryScenarios:
         await app._connect_gspro()
         assert app.gspro_client is not None
 
-        # Disconnect
+        # Disconnect (schedules async task via create_task)
         app._disconnect_gspro()
+
+        # Allow the scheduled disconnect task to complete (includes 0.25s grace period)
+        await asyncio.sleep(0.5)
         assert app.gspro_client is None
 
         # Reconnect
@@ -446,8 +452,11 @@ class TestShutdown:
         assert app.gc2_reader is not None
         assert app.gspro_client is not None
 
-        # Shutdown
+        # Shutdown (gspro disconnect is scheduled as async task)
         app.shutdown()
+
+        # Allow the scheduled GSPro disconnect task to complete (includes 0.25s grace period)
+        await asyncio.sleep(0.5)
 
         # Both should be disconnected
         assert app.gc2_reader is None

--- a/tests/integration/test_connection_handling.py
+++ b/tests/integration/test_connection_handling.py
@@ -4,79 +4,74 @@
 
 from __future__ import annotations
 
+import asyncio
 import socket
-import time
-from typing import TYPE_CHECKING
 
 from gc2_connect.gc2.usb_reader import MockGC2Reader
 from gc2_connect.gspro.client import GSProClient
 from gc2_connect.models import GC2ShotData
 
-if TYPE_CHECKING:
-    pass
-
 
 class TestGSProConnectionSuccess:
     """Test successful GSPro connections."""
 
-    def test_connect_to_mock_server(self, mock_gspro_server):
+    async def test_connect_to_mock_server(self, mock_gspro_server):
         """Test connecting to a mock GSPro server."""
         client = GSProClient(host=mock_gspro_server.host, port=mock_gspro_server.port)
 
-        connected = client.connect()
+        connected = await client.connect()
 
         assert connected is True
         assert client.is_connected is True
         assert client.shot_number == 0
 
-        client.disconnect()
+        await client.disconnect()
         assert client.is_connected is False
 
-    def test_multiple_connections_same_server(self, mock_gspro_server):
+    async def test_multiple_connections_same_server(self, mock_gspro_server):
         """Test connecting, disconnecting, and reconnecting."""
         client = GSProClient(host=mock_gspro_server.host, port=mock_gspro_server.port)
 
         # First connection
-        assert client.connect() is True
+        assert await client.connect() is True
         assert client.is_connected is True
-        client.disconnect()
+        await client.disconnect()
         assert client.is_connected is False
 
         # Give server time to accept new connection
-        time.sleep(0.1)
+        await asyncio.sleep(0.1)
 
         # Second connection
-        assert client.connect() is True
+        assert await client.connect() is True
         assert client.is_connected is True
-        client.disconnect()
+        await client.disconnect()
 
 
 class TestGSProConnectionFailure:
     """Test GSPro connection failure scenarios."""
 
-    def test_connect_to_wrong_host(self):
+    async def test_connect_to_wrong_host(self):
         """Test connecting to non-existent host."""
         client = GSProClient(host="192.168.255.255", port=921)
 
         # Should fail to connect (timeout)
-        connected = client.connect()
+        connected = await client.connect()
 
         assert connected is False
         assert client.is_connected is False
 
-    def test_connect_to_wrong_port(self):
+    async def test_connect_to_wrong_port(self):
         """Test connecting to wrong port."""
         client = GSProClient(host="127.0.0.1", port=65000)
 
-        connected = client.connect()
+        connected = await client.connect()
 
         assert connected is False
         assert client.is_connected is False
 
-    def test_connect_to_closed_server(self):
+    async def test_connect_to_closed_server(self):
         """Test connecting to a server that is not running."""
         # Use a port that nothing is listening on
-
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 0))
             closed_port = s.getsockname()[1]
@@ -84,7 +79,7 @@ class TestGSProConnectionFailure:
         # Socket is closed, port is no longer listening
         client = GSProClient(host="127.0.0.1", port=closed_port)
 
-        connected = client.connect()
+        connected = await client.connect()
 
         assert connected is False
         assert client.is_connected is False
@@ -93,75 +88,54 @@ class TestGSProConnectionFailure:
 class TestGSProDisconnection:
     """Test GSPro disconnection scenarios."""
 
-    def test_send_after_disconnect(
+    async def test_send_after_disconnect(
         self, mock_gspro_server, gspro_client: GSProClient, sample_gc2_shot: GC2ShotData
     ):
-        """Test that sending after disconnect returns None."""
-        gspro_client.disconnect()
+        """Test that sending after disconnect returns without error."""
+        await gspro_client.disconnect()
 
-        response = gspro_client.send_shot(sample_gc2_shot)
+        # send_shot returns None (fire-and-forget, no exception on disconnect)
+        result = await gspro_client.send_shot(sample_gc2_shot)
 
-        assert response is None
+        assert result is None
         assert gspro_client.is_connected is False
 
-    def test_disconnect_callback_invoked_on_socket_error(self):
-        """Test that disconnect callback is invoked when socket error occurs."""
-        import threading
+    async def test_disconnect_callback_invoked_on_server_close(self, mock_gspro_server):
+        """Test that disconnect callback is invoked when server closes connection."""
+        from tests.simulators.gspro.config import MockGSProServerConfig, ResponseType
+        from tests.simulators.gspro.server import MockGSProServer
 
-        # Create a server that sends RST to cause a socket error
-        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        server.bind(("127.0.0.1", 0))
-        server.listen(1)
-        port = server.getsockname()[1]
-
-        def accept_and_reset():
-            conn, _ = server.accept()
-            # Read heartbeat data
-            try:
-                conn.recv(4096)
-            except Exception:
-                pass
-            # Set linger to 0 to send RST on close, causing socket error on client
-            conn.setsockopt(
-                socket.SOL_SOCKET, socket.SO_LINGER, b"\x01\x00\x00\x00\x00\x00\x00\x00"
-            )
-            conn.close()
-            server.close()
-
-        thread = threading.Thread(target=accept_and_reset, daemon=True)
-        thread.start()
-
-        client = GSProClient(host="127.0.0.1", port=port)
-        client.connect()
-
-        disconnect_called = [False]
-
-        def on_disconnect() -> None:
-            disconnect_called[0] = True
-
-        client.add_disconnect_callback(on_disconnect)
-
-        # Wait for server to close
-        time.sleep(0.3)
-
-        # Try to send - should detect disconnection via socket error
-        shot = GC2ShotData(
-            shot_id=1,
-            ball_speed=145,
-            launch_angle=12,
-            total_spin=2500,
-            back_spin=2400,
-            side_spin=100,
+        # Use a server that disconnects after one shot
+        config = MockGSProServerConfig(
+            host="127.0.0.1",
+            port=0,
+            response_type=ResponseType.DISCONNECT,
         )
-        response = client.send_shot(shot)
+        async with MockGSProServer(config) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            await client.connect()
 
-        # Either: socket error detected disconnection, or empty response received
-        # The client marks disconnected only on OSError, not on empty response
-        # If RST was sent, OSError occurs and is_connected becomes False
-        # If graceful close, empty response is received and is_connected stays True
-        # Either way, send_shot returns None when connection issues occur
-        assert response is None
+            disconnect_called = asyncio.Event()
+
+            def on_disconnect() -> None:
+                disconnect_called.set()
+
+            client.add_disconnect_callback(on_disconnect)
+
+            # Send a shot - server will disconnect immediately
+            shot = GC2ShotData(
+                shot_id=1,
+                ball_speed=145,
+                launch_angle=12,
+                total_spin=2500,
+                back_spin=2400,
+                side_spin=100,
+            )
+            await client.send_shot(shot)
+
+            # Wait for disconnect callback
+            await asyncio.wait_for(disconnect_called.wait(), timeout=2.0)
+            assert disconnect_called.is_set()
 
 
 class TestMockGC2Connection:
@@ -205,27 +179,25 @@ class TestMockGC2Connection:
 class TestHeartbeat:
     """Test heartbeat functionality."""
 
-    def test_heartbeat_sent_on_connect(self, mock_gspro_server):
+    async def test_heartbeat_sent_on_connect(self, mock_gspro_server):
         """Test that heartbeat is sent on connect."""
         client = GSProClient(host=mock_gspro_server.host, port=mock_gspro_server.port)
 
-        client.connect()
+        await client.connect()
 
         # Give time for heartbeat to be processed
-        time.sleep(0.1)
+        await asyncio.sleep(0.1)
 
-        # Heartbeat should have been received (may not show as a shot)
-        # The connect() method sends a heartbeat but doesn't wait for response
+        # Heartbeat should have been received by server
+        await client.disconnect()
 
-        client.disconnect()
-
-    def test_manual_heartbeat(self, mock_gspro_server, gspro_client: GSProClient):
+    async def test_manual_heartbeat(self, mock_gspro_server, gspro_client: GSProClient):
         """Test sending manual heartbeat."""
         # Note: GSPro doesn't respond to heartbeats
-        response = gspro_client.send_heartbeat()
+        result = await gspro_client.send_heartbeat()
 
-        # Heartbeat doesn't expect response
-        assert response is None
+        # Heartbeat returns None
+        assert result is None
 
         # Client should still be connected
         assert gspro_client.is_connected is True
@@ -249,7 +221,7 @@ class TestBallStatus:
         assert statuses[0].flags == 7  # Green light
         assert statuses[0].ball_count == 1
 
-    def test_send_status_to_gspro(
+    async def test_send_status_to_gspro(
         self, mock_gspro_server, gspro_client: GSProClient, mock_gc2_reader: MockGC2Reader
     ):
         """Test that ball status can be sent to GSPro."""
@@ -258,11 +230,11 @@ class TestBallStatus:
 
         assert status is not None
 
-        # Send status (doesn't expect response)
-        response = gspro_client.send_status(status)
+        # Send status (fire-and-forget, returns None)
+        result = await gspro_client.send_status(status)
 
-        # Should not expect response for status
-        assert response is None
+        # Should return None (no response expected)
+        assert result is None
 
         # Client should still be connected
         assert gspro_client.is_connected is True

--- a/tests/integration/test_gspro_client_async.py
+++ b/tests/integration/test_gspro_client_async.py
@@ -1,0 +1,141 @@
+# ABOUTME: Integration tests for GSProClient async I/O behavior against MockGSProServer.
+# ABOUTME: Covers newline framing, keepalive, dropped-connection handling, and handshake.
+"""Async integration tests for GSProClient."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+
+import pytest
+
+from gc2_connect.gspro.client import GSProClient
+from gc2_connect.models import GC2BallStatus, GC2ShotData
+from tests.simulators.gspro.config import MockGSProServerConfig, ResponseType
+from tests.simulators.gspro.server import MockGSProServer
+
+
+class TestNewlineFraming:
+    @pytest.mark.asyncio
+    async def test_every_outbound_write_ends_in_newline(self) -> None:
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            connected = await client.connect()
+            assert connected
+
+            try:
+                shot = GC2ShotData(
+                    ball_speed=140.0,
+                    launch_angle=12.0,
+                    horizontal_launch_angle=1.0,
+                    total_spin=2500.0,
+                    back_spin=2400.0,
+                    side_spin=-200.0,
+                )
+                await client.send_shot(shot)
+                await client.send_heartbeat()
+                await client.send_status(GC2BallStatus(flags=7, ball_count=1))
+
+                await asyncio.sleep(0.1)
+            finally:
+                await client.disconnect()
+
+            raw = b"".join(server.received_raw_bytes)
+            assert raw.count(b"\n") >= 4  # initial registration heartbeat + 3 above
+            for idx, b in enumerate(raw):
+                if b == 0x0A:
+                    assert raw[idx - 1 : idx] == b"}", (
+                        f"Newline at offset {idx} not preceded by '}}': "
+                        f"context={raw[max(0, idx - 20) : idx + 1]!r}"
+                    )
+
+
+class TestKeepalive:
+    @pytest.mark.asyncio
+    async def test_so_keepalive_enabled_after_connect(self) -> None:
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            await client.connect()
+            try:
+                assert client._writer is not None
+                sock = client._writer.get_extra_info("socket")
+                ka = sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE)
+                assert ka != 0  # Non-zero means keepalive is enabled
+            finally:
+                await client.disconnect()
+
+
+class TestDroppedConnection:
+    @pytest.mark.asyncio
+    async def test_reader_loop_triggers_disconnect_callback_on_eof(self) -> None:
+        disconnect_fired = asyncio.Event()
+
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            client.add_disconnect_callback(lambda: disconnect_fired.set())
+            await client.connect()
+
+            # Give the server handler time to register the connection
+            await asyncio.sleep(0.1)
+            await server.close_all_connections()
+
+            await asyncio.wait_for(disconnect_fired.wait(), timeout=2.0)
+            assert client.is_connected is False
+
+
+class TestSendShotReturnsNone:
+    @pytest.mark.asyncio
+    async def test_send_shot_returns_none_and_ack_arrives_via_callback(self) -> None:
+        async with MockGSProServer(
+            MockGSProServerConfig(
+                response_type=ResponseType.SUCCESS,
+            )
+        ) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            await client.connect()
+
+            ack_received = asyncio.Event()
+            seen = []
+
+            def on_response(resp) -> None:
+                seen.append(resp)
+                if resp.Code == 200:
+                    ack_received.set()
+
+            client.add_response_callback(on_response)
+
+            try:
+                shot = GC2ShotData(
+                    ball_speed=140.0,
+                    launch_angle=12.0,
+                    horizontal_launch_angle=1.0,
+                    total_spin=2500.0,
+                    back_spin=2400.0,
+                    side_spin=-200.0,
+                )
+                result = await client.send_shot(shot)
+                assert result is None
+
+                await asyncio.wait_for(ack_received.wait(), timeout=2.0)
+                assert any(r.Code == 200 for r in seen)
+            finally:
+                await client.disconnect()
+
+
+class TestBareHandshake:
+    @pytest.mark.asyncio
+    async def test_bare_gspro_ready_string_fires_match_started(self) -> None:
+        async with MockGSProServer(MockGSProServerConfig()) as server:
+            client = GSProClient(host=server.host, port=server.port)
+            match_started = asyncio.Event()
+            client.add_match_started_callback(lambda: match_started.set())
+            await client.connect()
+
+            try:
+                # Give the server handler time to register the connection
+                await asyncio.sleep(0.1)
+                await server.send_raw_to_clients(b"GSPro ready\n")
+                await asyncio.wait_for(match_started.wait(), timeout=2.0)
+                assert client.match_started is True
+            finally:
+                await client.disconnect()

--- a/tests/integration/test_open_range_flow.py
+++ b/tests/integration/test_open_range_flow.py
@@ -12,6 +12,7 @@ to visualization. Covers:
 
 from __future__ import annotations
 
+import asyncio
 import time
 from unittest.mock import AsyncMock
 
@@ -307,6 +308,9 @@ class TestModeSwitchingWithConnections:
 
         # Should be able to send to GSPro
         await router.route_shot(sample_gc2_shot)
+
+        # Let the mock server's reader task process the shot
+        await asyncio.sleep(0.1)
 
         # Verify shot was received by GSPro server
         shot_messages = [

--- a/tests/integration/test_shot_flow.py
+++ b/tests/integration/test_shot_flow.py
@@ -4,15 +4,12 @@
 
 from __future__ import annotations
 
-import time
-from typing import TYPE_CHECKING, Any
+import asyncio
+from typing import Any
 
 from gc2_connect.gc2.usb_reader import MockGC2Reader
 from gc2_connect.gspro.client import GSProClient
 from gc2_connect.models import GC2ShotData, GSProResponse
-
-if TYPE_CHECKING:
-    pass
 
 
 def get_shot_messages(received_shots: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -27,17 +24,27 @@ def get_shot_messages(received_shots: list[dict[str, Any]]) -> list[dict[str, An
 class TestSingleShotFlow:
     """Test single shot flow from GC2 to GSPro."""
 
-    def test_valid_shot_is_sent_to_gspro(
+    async def test_valid_shot_is_sent_to_gspro(
         self, mock_gspro_server, gspro_client: GSProClient, sample_gc2_shot: GC2ShotData
     ):
         """Test that a valid shot from GC2 is correctly sent to GSPro."""
-        # Send shot through client
-        response = gspro_client.send_shot(sample_gc2_shot)
+        responses: list[GSProResponse] = []
 
-        # Verify response
-        assert response is not None
-        assert response.is_success
-        assert response.Code == 201  # Mock server returns 201 with player info
+        def on_response(r: GSProResponse) -> None:
+            responses.append(r)
+
+        gspro_client.add_response_callback(on_response)
+
+        # Send shot through client (fire-and-forget)
+        await gspro_client.send_shot(sample_gc2_shot)
+
+        # Wait for async response to arrive
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while not responses and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+
+        assert len(responses) >= 1
+        assert responses[0].is_success
 
         # Verify server received the shot (filter out heartbeat)
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
@@ -52,17 +59,29 @@ class TestSingleShotFlow:
         assert received["BallData"]["HLA"] == sample_gc2_shot.horizontal_launch_angle
         assert received["BallData"]["TotalSpin"] == sample_gc2_shot.total_spin
 
-    def test_shot_with_hmt_includes_club_data(
+    async def test_shot_with_hmt_includes_club_data(
         self,
         mock_gspro_server,
         gspro_client: GSProClient,
         sample_gc2_shot_with_hmt: GC2ShotData,
     ):
         """Test that shots with HMT data include club data in GSPro message."""
-        response = gspro_client.send_shot(sample_gc2_shot_with_hmt)
+        responses: list[GSProResponse] = []
 
-        assert response is not None
-        assert response.is_success
+        def on_response(r: GSProResponse) -> None:
+            responses.append(r)
+
+        gspro_client.add_response_callback(on_response)
+
+        await gspro_client.send_shot(sample_gc2_shot_with_hmt)
+
+        # Wait for async response to arrive
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while not responses and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+
+        assert len(responses) >= 1
+        assert responses[0].is_success
 
         # Verify club data is included (filter out heartbeat)
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
@@ -75,15 +94,17 @@ class TestSingleShotFlow:
         assert received["ClubData"]["AngleOfAttack"] == sample_gc2_shot_with_hmt.angle_of_attack
         assert received["ClubData"]["FaceToTarget"] == sample_gc2_shot_with_hmt.face_to_target
 
-    def test_shot_number_increments(
+    async def test_shot_number_increments(
         self, mock_gspro_server, gspro_client: GSProClient, sample_gc2_shot: GC2ShotData
     ):
         """Test that shot numbers increment correctly."""
         # Send multiple shots
         for expected_num in range(1, 4):
-            response = gspro_client.send_shot(sample_gc2_shot)
-            assert response is not None
+            await gspro_client.send_shot(sample_gc2_shot)
             assert gspro_client.shot_number == expected_num
+
+        # Give server time to receive all shots
+        await asyncio.sleep(0.1)
 
         # Verify shot numbers on server (filter out heartbeat)
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
@@ -91,14 +112,17 @@ class TestSingleShotFlow:
         for i, shot in enumerate(shot_messages, 1):
             assert shot["ShotNumber"] == i
 
-    def test_spin_axis_calculated_correctly(
+    async def test_spin_axis_calculated_correctly(
         self, mock_gspro_server, gspro_client: GSProClient, sample_gc2_shot: GC2ShotData
     ):
         """Test that spin axis is calculated from back/side spin."""
-        response = gspro_client.send_shot(sample_gc2_shot)
+        await gspro_client.send_shot(sample_gc2_shot)
 
-        assert response is not None
+        # Wait for shot to be received
+        await asyncio.sleep(0.1)
+
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
+        assert len(shot_messages) >= 1
         received = shot_messages[0]
 
         # Spin axis should match calculated value
@@ -109,7 +133,7 @@ class TestSingleShotFlow:
 class TestMultipleShotsFlow:
     """Test multiple shots in sequence."""
 
-    def test_multiple_shots_sent_in_order(self, mock_gspro_server, gspro_client: GSProClient):
+    async def test_multiple_shots_sent_in_order(self, mock_gspro_server, gspro_client: GSProClient):
         """Test that multiple shots are sent and received in order."""
         shots = [
             GC2ShotData(
@@ -123,10 +147,23 @@ class TestMultipleShotsFlow:
             for i in range(1, 6)
         ]
 
+        responses: list[GSProResponse] = []
+
+        def on_response(r: GSProResponse) -> None:
+            responses.append(r)
+
+        gspro_client.add_response_callback(on_response)
+
         for shot in shots:
-            response = gspro_client.send_shot(shot)
-            assert response is not None
-            assert response.is_success
+            await gspro_client.send_shot(shot)
+
+        # Wait for all responses to arrive
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while len(responses) < 5 and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+
+        assert len(responses) == 5
+        assert all(r.is_success for r in responses)
 
         # Verify all shots received (filter out heartbeat)
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
@@ -137,13 +174,22 @@ class TestMultipleShotsFlow:
             expected_speed = 140 + (i + 1) * 5
             assert received["BallData"]["Speed"] == expected_speed
 
-    def test_shot_history_with_varying_data(self, mock_gspro_server, gspro_client: GSProClient):
+    async def test_shot_history_with_varying_data(
+        self, mock_gspro_server, gspro_client: GSProClient
+    ):
         """Test sending shots with varying ball speeds, spins, and angles."""
         test_data = [
             {"speed": 100, "spin": 6000, "launch": 25, "hla": 0},  # Wedge
             {"speed": 140, "spin": 4000, "launch": 15, "hla": -2},  # Mid-iron
             {"speed": 165, "spin": 2500, "launch": 12, "hla": 5},  # Driver
         ]
+
+        responses: list[GSProResponse] = []
+
+        def on_response(r: GSProResponse) -> None:
+            responses.append(r)
+
+        gspro_client.add_response_callback(on_response)
 
         for data in test_data:
             shot = GC2ShotData(
@@ -155,9 +201,15 @@ class TestMultipleShotsFlow:
                 back_spin=data["spin"] - 200,
                 side_spin=200,
             )
-            response = gspro_client.send_shot(shot)
-            assert response is not None
-            assert response.is_success
+            await gspro_client.send_shot(shot)
+
+        # Wait for all responses
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while len(responses) < 3 and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+
+        assert len(responses) == 3
+        assert all(r.is_success for r in responses)
 
         # Verify all shots have correct data (filter out heartbeat)
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
@@ -172,13 +224,13 @@ class TestMultipleShotsFlow:
 class TestMockGC2ToGSProFlow:
     """Test complete flow from MockGC2 through callback to GSPro."""
 
-    def test_mock_gc2_shot_callback_to_gspro(
+    async def test_mock_gc2_shot_callback_to_gspro(
         self, mock_gspro_server, mock_gc2_reader: MockGC2Reader
     ):
         """Test that MockGC2 shots flow through callback to GSPro client."""
         # Create GSPro client
         client = GSProClient(host=mock_gspro_server.host, port=mock_gspro_server.port)
-        connected = client.connect()
+        connected = await client.connect()
         assert connected
 
         try:
@@ -186,22 +238,30 @@ class TestMockGC2ToGSProFlow:
 
             def on_shot(shot: GC2ShotData) -> None:
                 received_shots.append(shot)
-                # Send to GSPro
-                client.send_shot(shot)
+                # Schedule send_shot as an async task
+                asyncio.get_event_loop().create_task(client.send_shot(shot))
 
             # Register callback
             mock_gc2_reader.add_shot_callback(on_shot)
             mock_gc2_reader.connect()
 
-            # Wait for heartbeat response to be processed
-            time.sleep(0.1)
+            # Give time for heartbeat response to be processed
+            await asyncio.sleep(0.1)
 
             # Simulate test shots
             for _ in range(3):
                 mock_gc2_reader.send_test_shot()
 
+            # Wait for shots to be processed
+            deadline = asyncio.get_event_loop().time() + 2.0
+            while len(received_shots) < 3 and asyncio.get_event_loop().time() < deadline:
+                await asyncio.sleep(0.05)
+
             # Verify shots received by callback
             assert len(received_shots) == 3
+
+            # Give time for shots to reach GSPro server
+            await asyncio.sleep(0.1)
 
             # Verify shots sent to GSPro (filter out heartbeat)
             shot_messages = get_shot_messages(mock_gspro_server.received_shots)
@@ -213,7 +273,7 @@ class TestMockGC2ToGSProFlow:
             assert len(set(shot_numbers)) == 3  # All unique
 
         finally:
-            client.disconnect()
+            await client.disconnect()
             mock_gc2_reader.disconnect()
 
     def test_shot_validation_prevents_sending(
@@ -268,7 +328,7 @@ class TestMockGC2ToGSProFlow:
 class TestShotDataTransformation:
     """Test shot data transformation from GC2 to GSPro format."""
 
-    def test_ball_data_mapping(self, mock_gspro_server, gspro_client: GSProClient):
+    async def test_ball_data_mapping(self, mock_gspro_server, gspro_client: GSProClient):
         """Test all ball data fields are correctly mapped."""
         shot = GC2ShotData(
             shot_id=1,
@@ -280,9 +340,13 @@ class TestShotDataTransformation:
             side_spin=-400,
         )
 
-        gspro_client.send_shot(shot)
+        await gspro_client.send_shot(shot)
+
+        # Wait for shot to be received
+        await asyncio.sleep(0.1)
 
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
+        assert len(shot_messages) >= 1
         received = shot_messages[0]["BallData"]
         assert received["Speed"] == 150.5
         assert received["VLA"] == 11.2
@@ -291,7 +355,7 @@ class TestShotDataTransformation:
         assert received["BackSpin"] == 2700
         assert received["SideSpin"] == -400
 
-    def test_club_data_mapping(self, mock_gspro_server, gspro_client: GSProClient):
+    async def test_club_data_mapping(self, mock_gspro_server, gspro_client: GSProClient):
         """Test all club data fields are correctly mapped."""
         shot = GC2ShotData(
             shot_id=1,
@@ -311,9 +375,13 @@ class TestShotDataTransformation:
             closure_rate=350.0,
         )
 
-        gspro_client.send_shot(shot)
+        await gspro_client.send_shot(shot)
+
+        # Wait for shot to be received
+        await asyncio.sleep(0.1)
 
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
+        assert len(shot_messages) >= 1
         received = shot_messages[0]["ClubData"]
         assert received["Speed"] == 105.5
         assert received["Path"] == 2.1
@@ -325,13 +393,17 @@ class TestShotDataTransformation:
         assert received["VerticalFaceImpact"] == -2.0
         assert received["ClosureRate"] == 350.0
 
-    def test_shot_options_correct(
+    async def test_shot_options_correct(
         self, mock_gspro_server, gspro_client: GSProClient, sample_gc2_shot: GC2ShotData
     ):
         """Test ShotDataOptions are set correctly."""
-        gspro_client.send_shot(sample_gc2_shot)
+        await gspro_client.send_shot(sample_gc2_shot)
+
+        # Wait for shot to be received
+        await asyncio.sleep(0.1)
 
         shot_messages = get_shot_messages(mock_gspro_server.received_shots)
+        assert len(shot_messages) >= 1
         options = shot_messages[0]["ShotDataOptions"]
         assert options["ContainsBallData"] is True
         assert options["ContainsClubData"] is False  # No club data in sample shot
@@ -343,7 +415,7 @@ class TestShotDataTransformation:
 class TestResponseHandling:
     """Test handling of GSPro responses."""
 
-    def test_response_callback_invoked(
+    async def test_response_callback_invoked(
         self, mock_gspro_server, gspro_client: GSProClient, sample_gc2_shot: GC2ShotData
     ):
         """Test that response callbacks are invoked on shot response."""
@@ -354,18 +426,34 @@ class TestResponseHandling:
 
         gspro_client.add_response_callback(on_response)
 
-        gspro_client.send_shot(sample_gc2_shot)
+        await gspro_client.send_shot(sample_gc2_shot)
 
-        # Give callback time to be invoked (synchronous call)
+        # Wait for callback to be invoked (async, arrives via reader loop)
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while not responses and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+
         assert len(responses) == 1
         assert responses[0].Code == 201  # Mock server returns 201 with player info
         assert responses[0].is_success
 
-    def test_player_info_extracted(
+    async def test_player_info_extracted(
         self, mock_gspro_server, gspro_client: GSProClient, sample_gc2_shot: GC2ShotData
     ):
         """Test that player info is extracted from response."""
-        gspro_client.send_shot(sample_gc2_shot)
+        responses: list[GSProResponse] = []
+
+        def on_response(response: GSProResponse) -> None:
+            responses.append(response)
+
+        gspro_client.add_response_callback(on_response)
+
+        await gspro_client.send_shot(sample_gc2_shot)
+
+        # Wait for response to arrive
+        deadline = asyncio.get_event_loop().time() + 2.0
+        while not responses and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
 
         # Mock server sends player info
         player = gspro_client.current_player

--- a/tests/simulators/gspro/server.py
+++ b/tests/simulators/gspro/server.py
@@ -77,6 +77,7 @@ class MockGSProServer:
         self._connections: list[asyncio.StreamWriter] = []
         self._running = False
         self._actual_port: int = 0
+        self.received_raw_bytes: list[bytes] = []
 
     @property
     def config(self) -> MockGSProServerConfig:
@@ -130,6 +131,29 @@ class MockGSProServer:
     def clear_shots(self) -> None:
         """Clear recorded shots."""
         self._shots.clear()
+
+    async def close_all_connections(self) -> None:
+        """Close all active client connections, simulating a server-side disconnect."""
+        for writer in list(self._connections):
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+        self._connections.clear()
+
+    async def send_raw_to_clients(self, data: bytes) -> None:
+        """Send raw bytes to all connected clients.
+
+        Args:
+            data: Raw bytes to send to each client.
+        """
+        for writer in list(self._connections):
+            try:
+                writer.write(data)
+                await writer.drain()
+            except Exception:
+                pass
 
     async def wait_for_shots(
         self,
@@ -214,8 +238,14 @@ class MockGSProServer:
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
-        """Handle a client connection."""
+        """Handle a client connection.
+
+        Uses a streaming buffer to correctly parse multiple newline-terminated
+        JSON objects that may arrive in a single read() call.
+        """
         self._connections.append(writer)
+        buffer = b""
+        decoder = json.JSONDecoder()
 
         try:
             while self._running:
@@ -227,30 +257,46 @@ class MockGSProServer:
                 if not data:
                     break
 
-                # Parse the message
-                try:
-                    message = json.loads(data.decode("utf-8"))
-                except json.JSONDecodeError:
-                    continue
+                # Record raw bytes received
+                self.received_raw_bytes.append(data)
+                buffer += data
 
-                # Record the shot
-                shot = ReceivedShot(
-                    shot_number=message.get("ShotNumber", 0),
-                    ball_data=message.get("BallData", {}),
-                    club_data=message.get("ClubData", {}),
-                    raw_message=message,
-                )
-                self._shots.append(shot)
+                # Parse all complete JSON objects from buffer
+                text = buffer.decode("utf-8", errors="replace")
+                while text.strip():
+                    text = text.lstrip()
+                    if not text:
+                        break
+                    try:
+                        message, end = decoder.raw_decode(text)
+                    except json.JSONDecodeError:
+                        # Incomplete JSON - wait for more data
+                        break
 
-                # Check disconnect after shots
-                if (
-                    self._config.disconnect_after_shots > 0
-                    and len(self._shots) >= self._config.disconnect_after_shots
-                ):
-                    break
+                    text = text[end:]
 
-                # Handle based on response type
-                await self._send_response(writer, shot)
+                    # Record the shot
+                    shot = ReceivedShot(
+                        shot_number=message.get("ShotNumber", 0),
+                        ball_data=message.get("BallData", {}),
+                        club_data=message.get("ClubData", {}),
+                        raw_message=message,
+                    )
+                    self._shots.append(shot)
+
+                    # Check disconnect after shots
+                    if (
+                        self._config.disconnect_after_shots > 0
+                        and len(self._shots) >= self._config.disconnect_after_shots
+                    ):
+                        writer.close()
+                        await writer.wait_closed()
+                        return
+
+                    # Handle based on response type
+                    await self._send_response(writer, shot)
+
+                buffer = text.encode("utf-8") if text else b""
 
         except Exception:
             pass

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -305,19 +305,17 @@ class TestGSProConnectionManager:
         registry = UICallbackRegistry()
         manager = GSProConnectionManager(registry)
 
-        with patch.object(manager, "_client", create=True):
-            # Create a mock client
-            mock_client = MagicMock()
-            mock_client.connect_async = AsyncMock(return_value=True)
-            mock_client.is_connected = True
-            mock_client._shot_number = 0
-            mock_client.add_disconnect_callback = MagicMock()
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock(return_value=True)
+        mock_client.is_connected = True
+        mock_client._shot_number = 0
+        mock_client.add_disconnect_callback = MagicMock()
 
-            with patch(
-                "gc2_connect.services.connection_manager.GSProClient",
-                return_value=mock_client,
-            ):
-                success = await manager.connect(host="127.0.0.1", port=921)
+        with patch(
+            "gc2_connect.services.connection_manager.GSProClient",
+            return_value=mock_client,
+        ):
+            success = await manager.connect(host="127.0.0.1", port=921)
 
         assert success
         assert manager.host == "127.0.0.1"
@@ -333,7 +331,7 @@ class TestGSProConnectionManager:
         registry.register_gspro_connect_callback(lambda s: connect_results.append(s), "token1")
 
         mock_client = MagicMock()
-        mock_client.connect_async = AsyncMock(return_value=True)
+        mock_client.connect = AsyncMock(return_value=True)
         mock_client.is_connected = True
         mock_client._shot_number = 0
         mock_client.add_disconnect_callback = MagicMock()
@@ -346,7 +344,8 @@ class TestGSProConnectionManager:
 
         assert connect_results == [True]
 
-    def test_shot_number_persists_across_disconnect(self) -> None:
+    @pytest.mark.asyncio
+    async def test_shot_number_persists_across_disconnect(self) -> None:
         """Test that shot number persists across disconnects."""
         registry = UICallbackRegistry()
         manager = GSProConnectionManager(registry)
@@ -357,10 +356,10 @@ class TestGSProConnectionManager:
         # Create mock client
         mock_client = MagicMock()
         mock_client.shot_number = 10
-        mock_client.disconnect = MagicMock()
+        mock_client.disconnect = AsyncMock()
         manager._client = mock_client
 
-        manager.disconnect()
+        await manager.disconnect()
 
         # Shot number should be preserved
         assert manager.shot_number == 10
@@ -374,7 +373,7 @@ class TestGSProConnectionManager:
         manager._shot_number = 15  # Previously had 15 shots
 
         mock_client = MagicMock()
-        mock_client.connect_async = AsyncMock(return_value=True)
+        mock_client.connect = AsyncMock(return_value=True)
         mock_client.is_connected = True
         mock_client._shot_number = 0  # Client starts at 0
         mock_client.add_disconnect_callback = MagicMock()
@@ -395,11 +394,11 @@ class TestGSProConnectionManager:
         manager = GSProConnectionManager(registry)
 
         mock_client = MagicMock()
-        mock_client.connect_async = AsyncMock(return_value=True)
+        mock_client.connect = AsyncMock(return_value=True)
         mock_client.is_connected = True
         mock_client._shot_number = 0
         mock_client.shot_number = 1  # After sending
-        mock_client.send_shot_async = AsyncMock(return_value={"Code": 200})
+        mock_client.send_shot = AsyncMock(return_value=None)
         mock_client.add_disconnect_callback = MagicMock()
 
         with patch(
@@ -409,10 +408,9 @@ class TestGSProConnectionManager:
             await manager.connect(host="127.0.0.1", port=921)
 
         shot = GC2ShotData(shot_id=1, ball_speed=150.0)
-        response = await manager.send_shot(shot)
+        await manager.send_shot(shot)
 
-        assert response == {"Code": 200}
-        mock_client.send_shot_async.assert_called_once_with(shot)
+        mock_client.send_shot.assert_called_once_with(shot)
 
 
 class TestSingletons:

--- a/tests/unit/test_gspro_client.py
+++ b/tests/unit/test_gspro_client.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from gc2_connect.gspro.client import DEFAULT_HOST, DEFAULT_PORT, GSProClient
 from gc2_connect.models import GC2ShotData, GSProResponse
@@ -48,80 +50,108 @@ class TestGSProClientConnectionState:
         client = GSProClient()
         assert client.shot_number == 0
 
-    def test_connect_success(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_connect_success(self):
         """Test successful connection."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            result = client.connect()
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.write = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
+
+        with (
+            patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)),
+            patch.object(client, "_reader_loop", new=AsyncMock()),
+        ):
+            result = await client.connect()
+
         assert result is True
         assert client.is_connected is True
 
-    def test_connect_failure(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_connect_failure(self):
         """Test failed connection."""
         client = GSProClient()
-        with patch("socket.create_connection", side_effect=OSError("Connection refused")):
-            result = client.connect()
+        with patch("asyncio.open_connection", side_effect=OSError("Connection refused")):
+            result = await client.connect()
+
         assert result is False
         assert client.is_connected is False
 
-    def test_disconnect(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_disconnect(self):
         """Test disconnect resets state."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-        assert client.is_connected is True
-        client.disconnect()
+        client._connected = True
+        writer = MagicMock()
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        writer.close = MagicMock()
+        writer.wait_closed = AsyncMock()
+        client._writer = writer
+
+        with patch.object(client, "_send_shutdown_heartbeat", new=AsyncMock()):
+            await client.disconnect()
+
         assert client.is_connected is False
 
-    def test_disconnect_when_not_connected(self):
+    @pytest.mark.asyncio
+    async def test_disconnect_when_not_connected(self):
         """Test disconnect when not connected does not error."""
         client = GSProClient()
-        client.disconnect()
+        await client.disconnect()
         assert client.is_connected is False
 
 
 class TestGSProClientMessageFormatting:
     """Tests for GSProClient message formatting."""
 
-    def test_send_shot_increments_shot_number(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket_with_success_response: MagicMock,
-    ):
+    @pytest.mark.asyncio
+    async def test_send_shot_increments_shot_number(self, sample_gc2_shot: GC2ShotData):
         """Test that send_shot increments the shot number."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket_with_success_response):
-            client.connect()
-            assert client.shot_number == 0
+        client._connected = True
+        writer = MagicMock()
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        client._writer = writer
 
-            client.send_shot(sample_gc2_shot)
-            assert client.shot_number == 1
+        assert client.shot_number == 0
 
-            client.send_shot(sample_gc2_shot)
-            assert client.shot_number == 2
+        await client.send_shot(sample_gc2_shot)
+        assert client.shot_number == 1
 
-    def test_send_shot_when_not_connected(self, sample_gc2_shot: GC2ShotData):
+        await client.send_shot(sample_gc2_shot)
+        assert client.shot_number == 2
+
+    @pytest.mark.asyncio
+    async def test_send_shot_when_not_connected(self, sample_gc2_shot: GC2ShotData):
         """Test that send_shot returns None when not connected."""
         client = GSProClient()
-        result = client.send_shot(sample_gc2_shot)
+        result = await client.send_shot(sample_gc2_shot)
         assert result is None
         assert client.shot_number == 0
 
-    def test_send_shot_message_structure(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket_with_success_response: MagicMock,
-    ):
+    @pytest.mark.asyncio
+    async def test_send_shot_message_structure(self, sample_gc2_shot: GC2ShotData):
         """Test that send_shot sends correctly formatted JSON."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket_with_success_response):
-            client.connect()
-            client.send_shot(sample_gc2_shot)
+        client._connected = True
+        writer = MagicMock()
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        client._writer = writer
 
-        # Verify sendall was called with valid JSON
-        call_args = mock_socket_with_success_response.sendall.call_args
-        sent_data = call_args[0][0].decode("utf-8")
-        message = json.loads(sent_data)
+        await client.send_shot(sample_gc2_shot)
+
+        # Verify write was called with valid JSON + newline
+        writer.write.assert_called()
+        sent_bytes = writer.write.call_args[0][0]
+        assert sent_bytes.endswith(b"\n")
+        message = json.loads(sent_bytes[:-1].decode("utf-8"))
 
         # Verify message structure
         assert "DeviceID" in message
@@ -132,181 +162,149 @@ class TestGSProClientMessageFormatting:
         # Ball speed is sent as mph directly to GSPro
         assert message["BallData"]["Speed"] == sample_gc2_shot.ball_speed
 
-    def test_heartbeat_message_structure(
-        self,
-        mock_socket: MagicMock,
-    ):
+    @pytest.mark.asyncio
+    async def test_heartbeat_message_structure(self):
         """Test that heartbeat sends correctly formatted message."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-            # Second heartbeat (first is sent during connect)
-            client.send_heartbeat()
+        client._connected = True
+        writer = MagicMock()
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        client._writer = writer
 
-        # Verify sendall was called with valid JSON (check last call)
-        call_args = mock_socket.sendall.call_args
-        sent_data = call_args[0][0].decode("utf-8")
-        message = json.loads(sent_data)
+        await client.send_heartbeat()
+
+        # Verify write was called with valid JSON + newline
+        writer.write.assert_called_once()
+        sent_bytes = writer.write.call_args[0][0]
+        assert sent_bytes.endswith(b"\n")
+        message = json.loads(sent_bytes[:-1].decode("utf-8"))
 
         # Verify heartbeat message
         assert message["ShotDataOptions"]["IsHeartBeat"] is True
         assert message["ShotDataOptions"]["ContainsBallData"] is False
         assert message["ShotDataOptions"]["ContainsClubData"] is False
 
-    def test_send_heartbeat_when_not_connected(self):
+    @pytest.mark.asyncio
+    async def test_send_heartbeat_when_not_connected(self):
         """Test that send_heartbeat returns None when not connected."""
         client = GSProClient()
-        result = client.send_heartbeat()
+        result = await client.send_heartbeat()
         assert result is None
 
-    def test_send_heartbeat_returns_none(
-        self,
-        mock_socket: MagicMock,
-    ):
+    @pytest.mark.asyncio
+    async def test_send_heartbeat_returns_none(self):
         """Test that send_heartbeat returns None (GSPro doesn't respond to heartbeats)."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-            result = client.send_heartbeat()
+        client._connected = True
+        writer = MagicMock()
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        client._writer = writer
+
+        result = await client.send_heartbeat()
         assert result is None
 
 
 class TestGSProClientResponseParsing:
-    """Tests for GSProClient response parsing."""
+    """Tests for GSProClient response parsing via _drain_buffer and _handle_response."""
 
-    def test_response_parsing_success(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket_with_success_response: MagicMock,
-    ):
-        """Test parsing of success response."""
+    def test_handle_response_code_200_fires_response_callback(self):
+        """Test that code 200 fires response callbacks."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket_with_success_response):
-            client.connect()
-            response = client.send_shot(sample_gc2_shot)
+        responses = []
+        client.add_response_callback(lambda r: responses.append(r))
 
-        assert response is not None
-        assert response.Code == 200
-        assert response.is_success is True
+        client._handle_response({"Code": 200, "Message": "Shot received"})
 
-    def test_response_parsing_player_info(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket_with_player_response: MagicMock,
-    ):
-        """Test parsing of response with player info."""
+        assert len(responses) == 1
+        assert responses[0].Code == 200
+        assert responses[0].is_success is True
+
+    def test_handle_response_code_201_updates_player(self):
+        """Test that code 201 updates current_player."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket_with_player_response):
-            client.connect()
-            response = client.send_shot(sample_gc2_shot)
+        player_data = {"Handed": "RH", "Club": "DR"}
 
-        assert response is not None
-        assert response.Code == 201
-        assert response.Player is not None
-        assert response.Player["Handed"] == "RH"
-        assert response.Player["Club"] == "DR"
+        client._handle_response({"Code": 201, "Player": player_data, "Message": "Player info"})
 
-        # Verify client stores player info
         assert client.current_player is not None
         assert client.current_player["Handed"] == "RH"
 
-    def test_response_parsing_error_code(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket: MagicMock,
-    ):
-        """Test parsing of error response."""
-        error_response = {"Code": 500, "Message": "Internal error"}
-        mock_socket.recv.return_value = json.dumps(error_response).encode("utf-8")
-
+    def test_handle_response_error_code(self):
+        """Test that error codes fire response callbacks."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-            response = client.send_shot(sample_gc2_shot)
+        responses = []
+        client.add_response_callback(lambda r: responses.append(r))
 
-        assert response is not None
-        assert response.Code == 500
-        assert response.is_success is False
-        assert response.Message == "Internal error"
+        client._handle_response({"Code": 500, "Message": "Internal error"})
 
-    def test_empty_response(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket: MagicMock,
-    ):
-        """Test handling of empty response."""
-        mock_socket.recv.return_value = b""
+        assert len(responses) == 1
+        assert responses[0].Code == 500
+        assert responses[0].is_success is False
+        assert responses[0].Message == "Internal error"
 
+    def test_drain_buffer_parses_json(self):
+        """Test that _drain_buffer correctly parses a JSON object."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-            response = client.send_shot(sample_gc2_shot)
+        responses = []
+        client.add_response_callback(lambda r: responses.append(r))
 
-        assert response is None
+        data = json.dumps({"Code": 200, "Message": "OK"}).encode("utf-8")
+        remainder = client._drain_buffer(data)
 
-    def test_invalid_json_response(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket: MagicMock,
-    ):
-        """Test handling of invalid JSON response."""
-        mock_socket.recv.return_value = b"not valid json"
+        assert len(responses) == 1
+        assert responses[0].Code == 200
+        assert remainder == b""
 
+    def test_drain_buffer_handles_multiple_objects(self):
+        """Test that _drain_buffer handles multiple JSON objects."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-            response = client.send_shot(sample_gc2_shot)
+        responses = []
+        client.add_response_callback(lambda r: responses.append(r))
 
-        assert response is None
+        data = json.dumps({"Code": 200, "Message": "OK"}).encode("utf-8") + json.dumps(
+            {"Code": 201, "Message": "Player info", "Player": {}}
+        ).encode("utf-8")
+        remainder = client._drain_buffer(data)
 
-    def test_socket_timeout(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket: MagicMock,
-    ):
-        """Test handling of socket timeout."""
-        mock_socket.recv.side_effect = TimeoutError("Timeout")
+        assert len(responses) == 2
+        assert remainder == b""
 
+    def test_drain_buffer_returns_incomplete(self):
+        """Test that _drain_buffer returns incomplete JSON."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-            response = client.send_shot(sample_gc2_shot)
+        incomplete = b'{"Code": 200, "Mes'
+        remainder = client._drain_buffer(incomplete)
+        assert remainder == incomplete
 
-        assert response is None
-
-    def test_socket_error_disconnects(
-        self,
-        sample_gc2_shot: GC2ShotData,
-    ):
-        """Test that socket error sets connected to False."""
-        # Create a custom mock for this test
-        mock = MagicMock()
-        mock.sendall.return_value = None
-        mock.setsockopt.return_value = None
-        mock.settimeout.return_value = None
-
-        # Track blocking mode and configure recv to:
-        # 1. Raise BlockingIOError in non-blocking mode (buffer clear)
-        # 2. Raise OSError in blocking mode (simulating connection reset)
-        mock._blocking = True
-
-        def setblocking(blocking: bool):
-            mock._blocking = blocking
-
-        def recv_side_effect(_size: int):
-            if not mock._blocking:
-                raise BlockingIOError("Resource temporarily unavailable")
-            raise OSError("Connection reset")
-
-        mock.setblocking.side_effect = setblocking
-        mock.recv.side_effect = recv_side_effect
-
+    def test_drain_buffer_handles_gspro_ready(self):
+        """Test that _drain_buffer handles bare 'GSPro ready' string."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock):
-            client.connect()
-            assert client.is_connected is True
-            client.send_shot(sample_gc2_shot)
-            assert client.is_connected is False
+        match_started_events = []
+        client.add_match_started_callback(lambda: match_started_events.append(True))
+
+        with (
+            patch.object(client, "_start_heartbeat_timer"),
+            patch.object(client, "_schedule_heartbeat"),
+        ):
+            remainder = client._drain_buffer(b"GSPro ready\n")
+
+        assert client.match_started is True
+        assert remainder == b""
+
+    @pytest.mark.asyncio
+    async def test_send_shot_returns_none(self, sample_gc2_shot: GC2ShotData):
+        """Test that send_shot returns None (ack arrives via callback)."""
+        client = GSProClient()
+        client._connected = True
+        writer = MagicMock()
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        client._writer = writer
+
+        result = await client.send_shot(sample_gc2_shot)
+        assert result is None
 
 
 class TestGSProClientCallbacks:
@@ -334,44 +332,30 @@ class TestGSProClientCallbacks:
         client.remove_response_callback(callback)
         # Should not raise an error
 
-    def test_callback_invoked_on_response(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket_with_success_response: MagicMock,
-    ):
-        """Test that callbacks are invoked when response is received."""
+    def test_callback_invoked_on_handle_response(self):
+        """Test that callbacks are invoked when _handle_response is called."""
         client = GSProClient()
         callback = MagicMock()
+        client.add_response_callback(callback)
 
-        with patch("socket.create_connection", return_value=mock_socket_with_success_response):
-            client.connect()
-            # Add callback after connect so we only see shot responses
-            client.add_response_callback(callback)
-            client.send_shot(sample_gc2_shot)
+        client._handle_response({"Code": 200, "Message": "OK"})
 
         callback.assert_called_once()
         response = callback.call_args[0][0]
         assert isinstance(response, GSProResponse)
         assert response.Code == 200
 
-    def test_callback_exception_does_not_break_others(
-        self,
-        sample_gc2_shot: GC2ShotData,
-        mock_socket_with_success_response: MagicMock,
-    ):
+    def test_callback_exception_does_not_break_others(self):
         """Test that callback exceptions don't prevent other callbacks."""
         client = GSProClient()
         failing_callback = MagicMock(side_effect=Exception("Callback error"))
         working_callback = MagicMock()
 
-        with patch("socket.create_connection", return_value=mock_socket_with_success_response):
-            client.connect()
-            # Add callbacks after connect so we only see shot responses
-            client.add_response_callback(failing_callback)
-            client.add_response_callback(working_callback)
-            client.send_shot(sample_gc2_shot)
+        client.add_response_callback(failing_callback)
+        client.add_response_callback(working_callback)
 
-        # Both callbacks should have been called
+        client._handle_response({"Code": 200, "Message": "OK"})
+
         failing_callback.assert_called_once()
         working_callback.assert_called_once()
 

--- a/tests/unit/test_gspro_disconnect.py
+++ b/tests/unit/test_gspro_disconnect.py
@@ -1,216 +1,156 @@
 # ABOUTME: Unit tests for GSPro clean disconnect handling.
-# ABOUTME: Tests the shutdown sequence: send LaunchMonitorIsReady=false, flush, wait, close.
+# ABOUTME: Tests the shutdown sequence: send LaunchMonitorIsReady=false, drain, close.
 """Unit tests for GSPro clean disconnect functionality."""
 
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from gc2_connect.gspro.client import GSProClient
 
 
+def make_connected_client() -> tuple[GSProClient, MagicMock]:
+    """Return a GSProClient in connected state with a mocked writer."""
+    client = GSProClient()
+    client._connected = True
+    writer = MagicMock()
+    writer.write = MagicMock()
+    writer.drain = AsyncMock()
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    client._writer = writer
+    return client, writer
+
+
 class TestGSProCleanDisconnect:
     """Tests for GSProClient clean disconnect sequence."""
 
-    def test_disconnect_sends_shutdown_heartbeat(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_disconnect_sends_shutdown_heartbeat(self):
         """Test that disconnect sends a heartbeat with LaunchMonitorIsReady=false."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
+        client, writer = make_connected_client()
 
-        # Clear the call history from connect's initial heartbeat
-        mock_socket.sendall.reset_mock()
+        # Clear any setup writes
+        writer.write.reset_mock()
 
-        # Now disconnect
-        client.disconnect()
+        await client.disconnect()
 
         # Should have sent a shutdown heartbeat
-        assert mock_socket.sendall.called
-        sent_data = mock_socket.sendall.call_args[0][0].decode("utf-8")
-        message = json.loads(sent_data)
+        assert writer.write.called
+        sent_bytes = writer.write.call_args[0][0]
+        assert sent_bytes.endswith(b"\n")
+        message = json.loads(sent_bytes[:-1].decode("utf-8"))
 
         assert message["ShotDataOptions"]["IsHeartBeat"] is True
         assert message["ShotDataOptions"]["LaunchMonitorIsReady"] is False
         assert message["ShotDataOptions"]["ContainsBallData"] is False
         assert message["ShotDataOptions"]["ContainsClubData"] is False
 
-    def test_disconnect_waits_before_close(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_disconnect_waits_before_close(self):
         """Test that disconnect waits after sending heartbeat before closing."""
+        client, writer = make_connected_client()
+
+        with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await client.disconnect()
+
+        # Should have slept for the grace period
+        mock_sleep.assert_called()
+        sleep_durations = [call[0][0] for call in mock_sleep.call_args_list]
+        assert any(0.24 <= d <= 0.26 for d in sleep_durations)
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_writer_after_delay(self):
+        """Test that disconnect closes the writer after the delay."""
+        client, writer = make_connected_client()
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await client.disconnect()
+
+        writer.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_handles_writer_already_none(self):
+        """Test that disconnect handles writer being None."""
         client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-
-        with patch("time.sleep") as mock_sleep:
-            client.disconnect()
-
-        # Should wait 250ms for GSPro to process the heartbeat
-        mock_sleep.assert_called_once()
-        sleep_duration = mock_sleep.call_args[0][0]
-        assert 0.24 <= sleep_duration <= 0.26
-
-    def test_disconnect_closes_socket_after_delay(self, mock_socket: MagicMock):
-        """Test that disconnect closes the socket after the delay."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-
-        with patch("time.sleep"):
-            client.disconnect()
-
-        mock_socket.close.assert_called_once()
-
-    def test_disconnect_handles_socket_already_closed(self):
-        """Test that disconnect handles socket already being closed."""
-        client = GSProClient()
-        # Set up client as if it was connected
-        client._connected = True
-        client._socket = None  # Socket is None, simulating already closed
+        client._connected = False
+        client._writer = None
 
         # Should not raise any exceptions
-        client.disconnect()
+        await client.disconnect()
 
         assert client.is_connected is False
 
-    def test_disconnect_handles_send_failure_gracefully(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_disconnect_handles_send_failure_gracefully(self):
         """Test that disconnect handles failures when sending shutdown heartbeat."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
+        client, writer = make_connected_client()
 
-        # Make sendall fail
-        mock_socket.sendall.side_effect = OSError("Connection reset")
+        # Make drain fail (write/drain are the shutdown heartbeat path)
+        writer.drain.side_effect = OSError("Connection reset")
 
-        with patch("time.sleep"):
+        with patch("asyncio.sleep", new=AsyncMock()):
             # Should not raise, should continue with disconnect
-            client.disconnect()
+            await client.disconnect()
 
         assert client.is_connected is False
-        mock_socket.close.assert_called()
 
-    def test_disconnect_continues_after_heartbeat_failure(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_disconnect_continues_after_heartbeat_failure(self):
         """Test that disconnect continues with close even if heartbeat fails."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
+        client, writer = make_connected_client()
 
-        # Make sendall fail (heartbeat send fails)
-        mock_socket.sendall.side_effect = OSError("Connection reset")
+        # Make write fail on shutdown heartbeat
+        writer.write.side_effect = OSError("Connection reset")
 
-        with patch("time.sleep"):
+        with patch("asyncio.sleep", new=AsyncMock()):
             # Should not raise, should continue with close
-            client.disconnect()
+            await client.disconnect()
 
         assert client.is_connected is False
-        mock_socket.close.assert_called()
 
-    def test_disconnect_handles_close_failure_gracefully(self, mock_socket: MagicMock):
-        """Test that disconnect handles failures when closing socket."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
+    @pytest.mark.asyncio
+    async def test_disconnect_handles_close_failure_gracefully(self):
+        """Test that disconnect handles failures when closing writer."""
+        client, writer = make_connected_client()
 
-        # Make close fail
-        mock_socket.close.side_effect = OSError("Bad file descriptor")
+        # Make wait_closed fail
+        writer.wait_closed.side_effect = OSError("Bad file descriptor")
 
-        with patch("time.sleep"):
+        with patch("asyncio.sleep", new=AsyncMock()):
             # Should not raise
-            client.disconnect()
+            await client.disconnect()
 
         assert client.is_connected is False
 
-    def test_disconnect_clears_internal_state(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_internal_state(self):
         """Test that disconnect clears all internal state properly."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
+        client, writer = make_connected_client()
 
         # Simulate some state
         client._shot_number = 5
         client._current_player = {"Handed": "RH"}
 
-        with patch("time.sleep"):
-            client.disconnect()
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await client.disconnect()
 
-        assert client._socket is None
+        assert client._writer is None
         assert client._connected is False
         assert client._shot_number == 0
         assert client._current_player is None
 
-    def test_disconnect_when_not_connected_does_nothing(self):
+    @pytest.mark.asyncio
+    async def test_disconnect_when_not_connected_does_nothing(self):
         """Test that disconnect when not connected doesn't raise errors."""
         client = GSProClient()
         assert client.is_connected is False
 
         # Should not raise
-        client.disconnect()
-
-        assert client.is_connected is False
-
-    def test_disconnect_sequence_order(self, mock_socket: MagicMock):
-        """Test that disconnect performs steps in correct order."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-
-        mock_socket.reset_mock()
-        call_order: list[str] = []
-
-        def track_sendall(_data: bytes) -> None:
-            call_order.append("sendall")
-
-        def track_sleep(_duration: float) -> None:
-            call_order.append("sleep")
-
-        def track_close() -> None:
-            call_order.append("close")
-
-        mock_socket.sendall.side_effect = track_sendall
-        mock_socket.close.side_effect = track_close
-
-        with patch("time.sleep", side_effect=track_sleep):
-            client.disconnect()
-
-        # Verify order: sendall (heartbeat), sleep (wait for GSPro), close
-        assert call_order == ["sendall", "sleep", "close"]
-
-
-class TestGSProDisconnectAsync:
-    """Tests for async disconnect functionality."""
-
-    @pytest.mark.asyncio
-    async def test_disconnect_async_completes_all_steps(self, mock_socket: MagicMock):
-        """Test that async disconnect completes all steps."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-
-        mock_socket.reset_mock()
-
-        with patch("time.sleep"):
-            await client.disconnect_async()
-
-        assert client.is_connected is False
-        assert client._socket is None
-        mock_socket.sendall.assert_called()
-        mock_socket.close.assert_called()
-
-    @pytest.mark.asyncio
-    async def test_disconnect_async_handles_errors(self, mock_socket: MagicMock):
-        """Test that async disconnect handles errors gracefully."""
-        client = GSProClient()
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-
-        # Make everything fail
-        mock_socket.sendall.side_effect = OSError("Error")
-        mock_socket.close.side_effect = OSError("Error")
-
-        with patch("time.sleep"):
-            # Should not raise
-            await client.disconnect_async()
+        await client.disconnect()
 
         assert client.is_connected is False
 
@@ -218,21 +158,19 @@ class TestGSProDisconnectAsync:
 class TestGSProDisconnectCallbacks:
     """Tests for disconnect callbacks during clean disconnect."""
 
-    def test_disconnect_does_not_trigger_disconnect_callback(self, mock_socket: MagicMock):
+    @pytest.mark.asyncio
+    async def test_disconnect_does_not_trigger_disconnect_callback(self):
         """Test that intentional disconnect doesn't trigger disconnect callback.
 
         The disconnect callback should only be triggered on unexpected disconnections
         (e.g., network errors), not on intentional user-initiated disconnects.
         """
-        client = GSProClient()
+        client, writer = make_connected_client()
         callback = MagicMock()
         client.add_disconnect_callback(callback)
 
-        with patch("socket.create_connection", return_value=mock_socket):
-            client.connect()
-
-        with patch("time.sleep"):
-            client.disconnect()
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await client.disconnect()
 
         # Callback should NOT be called for intentional disconnect
         callback.assert_not_called()

--- a/tests/unit/test_gspro_heartbeat.py
+++ b/tests/unit/test_gspro_heartbeat.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -20,10 +20,13 @@ def client() -> GSProClient:
 
 @pytest.fixture
 def connected_client() -> Generator[GSProClient, None, None]:
-    """Create a GSProClient that appears connected."""
+    """Create a GSProClient that appears connected, with a mocked writer."""
     client = GSProClient()
     client._connected = True
-    client._socket = MagicMock()
+    writer = MagicMock()
+    writer.write = MagicMock()
+    writer.drain = AsyncMock()
+    client._writer = writer
     yield client
 
 
@@ -74,36 +77,36 @@ class TestSetHardwareReady:
     def test_set_hardware_ready_sends_status_during_match(
         self, connected_client: GSProClient
     ) -> None:
-        """Test set_hardware_ready sends status update when match is active."""
+        """Test set_hardware_ready schedules a heartbeat when match is active."""
         connected_client._match_started = True
 
-        with patch.object(connected_client, "send_heartbeat") as mock_heartbeat:
+        with patch.object(connected_client, "_schedule_heartbeat") as mock_schedule:
             connected_client.set_hardware_ready(True)
 
-            mock_heartbeat.assert_called_once()
+            mock_schedule.assert_called_once()
 
     def test_set_hardware_ready_no_status_when_no_match(
         self, connected_client: GSProClient
     ) -> None:
-        """Test set_hardware_ready doesn't send status when no match is active."""
+        """Test set_hardware_ready doesn't schedule heartbeat when no match is active."""
         connected_client._match_started = False
 
-        with patch.object(connected_client, "send_heartbeat") as mock_heartbeat:
+        with patch.object(connected_client, "_schedule_heartbeat") as mock_schedule:
             connected_client.set_hardware_ready(True)
 
-            mock_heartbeat.assert_not_called()
+            mock_schedule.assert_not_called()
 
     def test_set_hardware_ready_no_status_when_value_unchanged(
         self, connected_client: GSProClient
     ) -> None:
-        """Test set_hardware_ready doesn't send status when value doesn't change."""
+        """Test set_hardware_ready doesn't schedule heartbeat when value doesn't change."""
         connected_client._match_started = True
         connected_client._hardware_ready = True
 
-        with patch.object(connected_client, "send_heartbeat") as mock_heartbeat:
+        with patch.object(connected_client, "_schedule_heartbeat") as mock_schedule:
             connected_client.set_hardware_ready(True)  # Same value
 
-            mock_heartbeat.assert_not_called()
+            mock_schedule.assert_not_called()
 
 
 class TestOnMatchStarted:
@@ -115,7 +118,7 @@ class TestOnMatchStarted:
 
         with (
             patch.object(connected_client, "_start_heartbeat_timer"),
-            patch.object(connected_client, "send_heartbeat"),
+            patch.object(connected_client, "_schedule_heartbeat"),
         ):
             connected_client._on_match_started()
 
@@ -125,21 +128,21 @@ class TestOnMatchStarted:
         """Test _on_match_started starts the heartbeat timer."""
         with (
             patch.object(connected_client, "_start_heartbeat_timer") as mock_start_timer,
-            patch.object(connected_client, "send_heartbeat"),
+            patch.object(connected_client, "_schedule_heartbeat"),
         ):
             connected_client._on_match_started()
 
             mock_start_timer.assert_called_once()
 
     def test_on_match_started_sends_status(self, connected_client: GSProClient) -> None:
-        """Test _on_match_started sends current status."""
+        """Test _on_match_started schedules a heartbeat."""
         with (
             patch.object(connected_client, "_start_heartbeat_timer"),
-            patch.object(connected_client, "send_heartbeat") as mock_heartbeat,
+            patch.object(connected_client, "_schedule_heartbeat") as mock_schedule,
         ):
             connected_client._on_match_started()
 
-            mock_heartbeat.assert_called_once()
+            mock_schedule.assert_called_once()
 
     def test_on_match_started_idempotent(self, connected_client: GSProClient) -> None:
         """Test _on_match_started is idempotent (no double-start)."""
@@ -147,12 +150,12 @@ class TestOnMatchStarted:
 
         with (
             patch.object(connected_client, "_start_heartbeat_timer") as mock_start_timer,
-            patch.object(connected_client, "send_heartbeat") as mock_heartbeat,
+            patch.object(connected_client, "_schedule_heartbeat") as mock_schedule,
         ):
             connected_client._on_match_started()
 
             mock_start_timer.assert_not_called()
-            mock_heartbeat.assert_not_called()
+            mock_schedule.assert_not_called()
 
 
 class TestOnMatchEnded:
@@ -240,7 +243,7 @@ class TestHeartbeatLoop:
         connected_client._match_started = True
         heartbeat_count = 0
 
-        def mock_send_heartbeat() -> None:
+        async def mock_send_heartbeat() -> None:
             nonlocal heartbeat_count
             heartbeat_count += 1
             # Stop after 2 heartbeats
@@ -248,8 +251,10 @@ class TestHeartbeatLoop:
                 connected_client._match_started = False
 
         with (
-            patch.object(connected_client, "send_heartbeat", side_effect=mock_send_heartbeat),
-            patch("asyncio.sleep", return_value=None) as mock_sleep,
+            patch.object(
+                connected_client, "send_heartbeat", new=AsyncMock(side_effect=mock_send_heartbeat)
+            ),
+            patch("asyncio.sleep", new=AsyncMock(return_value=None)) as mock_sleep,
         ):
             await connected_client._heartbeat_loop()
 
@@ -271,7 +276,7 @@ class TestHeartbeatLoop:
                 connected_client._connected = False
 
         with (
-            patch.object(connected_client, "send_heartbeat"),
+            patch.object(connected_client, "send_heartbeat", new=AsyncMock()),
             patch("asyncio.sleep", side_effect=mock_sleep),
         ):
             await connected_client._heartbeat_loop()
@@ -292,7 +297,7 @@ class TestHeartbeatLoop:
                 connected_client._match_started = False
 
         with (
-            patch.object(connected_client, "send_heartbeat"),
+            patch.object(connected_client, "send_heartbeat", new=AsyncMock()),
             patch("asyncio.sleep", side_effect=mock_sleep),
         ):
             await connected_client._heartbeat_loop()
@@ -304,67 +309,67 @@ class TestHeartbeatLoop:
 class TestSendHeartbeatWithReadyState:
     """Test that send_heartbeat uses is_ready_to_report."""
 
-    def test_send_heartbeat_uses_is_ready_to_report_true(
+    @pytest.mark.asyncio
+    async def test_send_heartbeat_uses_is_ready_to_report_true(
         self, connected_client: GSProClient
     ) -> None:
         """Test send_heartbeat sends LaunchMonitorIsReady=true when is_ready_to_report is true."""
         connected_client._hardware_ready = True
         connected_client._match_started = True
 
-        mock_socket = connected_client._socket
-        assert mock_socket is not None
+        mock_writer = connected_client._writer
+        assert mock_writer is not None
 
-        # Set up socket to allow non-blocking check
-        mock_socket.recv.side_effect = BlockingIOError()
-
-        connected_client.send_heartbeat()
+        await connected_client.send_heartbeat()
 
         # Check the sent data
-        mock_socket.sendall.assert_called_once()
-        sent_data = mock_socket.sendall.call_args[0][0].decode("utf-8")
+        mock_writer.write.assert_called_once()
+        sent_data = mock_writer.write.call_args[0][0].decode("utf-8")
         assert '"LaunchMonitorIsReady": true' in sent_data
+        assert sent_data.endswith("\n")
 
-    def test_send_heartbeat_uses_is_ready_to_report_false(
+    @pytest.mark.asyncio
+    async def test_send_heartbeat_uses_is_ready_to_report_false(
         self, connected_client: GSProClient
     ) -> None:
         """Test send_heartbeat sends LaunchMonitorIsReady=false when is_ready_to_report is false."""
         connected_client._hardware_ready = True
         connected_client._match_started = False  # Match not started
 
-        mock_socket = connected_client._socket
-        assert mock_socket is not None
+        mock_writer = connected_client._writer
+        assert mock_writer is not None
 
-        # Set up socket to allow non-blocking check
-        mock_socket.recv.side_effect = BlockingIOError()
-
-        connected_client.send_heartbeat()
+        await connected_client.send_heartbeat()
 
         # Check the sent data
-        mock_socket.sendall.assert_called_once()
-        sent_data = mock_socket.sendall.call_args[0][0].decode("utf-8")
+        mock_writer.write.assert_called_once()
+        sent_data = mock_writer.write.call_args[0][0].decode("utf-8")
         assert '"LaunchMonitorIsReady": false' in sent_data
+        assert sent_data.endswith("\n")
 
 
 class TestDisconnectStopsHeartbeat:
     """Test that disconnect stops the heartbeat timer."""
 
-    def test_disconnect_stops_heartbeat_timer(self, connected_client: GSProClient) -> None:
+    @pytest.mark.asyncio
+    async def test_disconnect_stops_heartbeat_timer(self, connected_client: GSProClient) -> None:
         """Test disconnect stops the heartbeat timer."""
         mock_task = MagicMock()
         connected_client._heartbeat_task = mock_task
 
-        with patch.object(connected_client, "_send_shutdown_heartbeat"):
-            connected_client.disconnect()
+        with patch.object(connected_client, "_send_shutdown_heartbeat", new=AsyncMock()):
+            await connected_client.disconnect()
 
         mock_task.cancel.assert_called_once()
         assert connected_client._heartbeat_task is None
 
-    def test_disconnect_clears_match_state(self, connected_client: GSProClient) -> None:
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_match_state(self, connected_client: GSProClient) -> None:
         """Test disconnect clears match state."""
         connected_client._match_started = True
 
-        with patch.object(connected_client, "_send_shutdown_heartbeat"):
-            connected_client.disconnect()
+        with patch.object(connected_client, "_send_shutdown_heartbeat", new=AsyncMock()):
+            await connected_client.disconnect()
 
         assert connected_client._match_started is False
 

--- a/tests/unit/test_gspro_reader.py
+++ b/tests/unit/test_gspro_reader.py
@@ -5,9 +5,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Generator
-from typing import Any
-from unittest.mock import MagicMock, patch
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -16,85 +15,63 @@ from gc2_connect.gspro.client import GSProClient
 
 @pytest.fixture
 def connected_client() -> Generator[GSProClient, None, None]:
-    """Create a GSProClient configured for reader loop testing."""
+    """Create a GSProClient that appears connected with a mocked writer."""
     client = GSProClient()
     client._connected = True
-    client._reader_running = True
-    client._socket = MagicMock()
+    writer = MagicMock()
+    writer.write = MagicMock()
+    writer.drain = AsyncMock()
+    client._writer = writer
     yield client
-
-
-def get_mock_socket(client: GSProClient) -> MagicMock:
-    """Get the mock socket from a test client."""
-    return client._socket  # type: ignore[return-value]
-
-
-def create_socket_recv_sequence(client: GSProClient, *responses: bytes) -> Callable[[int], bytes]:
-    """Create a recv side effect that returns responses in sequence, then stops the loop.
-
-    After all responses are returned, raises BlockingIOError and stops the reader loop.
-    """
-    response_iter = iter(responses)
-
-    def recv_side_effect(_size: int) -> bytes:
-        try:
-            return next(response_iter)
-        except StopIteration:
-            client._reader_running = False
-            raise BlockingIOError() from None
-
-    return recv_side_effect
 
 
 class TestGSProReaderCallbacks:
     """Test callback registration and management."""
 
-    @pytest.mark.parametrize(
-        "add_method,list_attr",
-        [
-            ("add_player_info_callback", "_player_info_callbacks"),
-            ("add_match_started_callback", "_match_started_callbacks"),
-            ("add_match_ended_callback", "_match_ended_callbacks"),
-        ],
-    )
-    def test_add_callback(self, add_method: str, list_attr: str) -> None:
-        """Test adding callbacks for each event type."""
+    def test_add_player_info_callback(self) -> None:
+        """Test adding player info callback."""
         client = GSProClient()
         callback = MagicMock()
+        client.add_player_info_callback(callback)
+        assert callback in client._player_info_callbacks
 
-        getattr(client, add_method)(callback)
-
-        assert callback in getattr(client, list_attr)
-
-    @pytest.mark.parametrize(
-        "add_method,remove_method,list_attr",
-        [
-            (
-                "add_player_info_callback",
-                "remove_player_info_callback",
-                "_player_info_callbacks",
-            ),
-            (
-                "add_match_started_callback",
-                "remove_match_started_callback",
-                "_match_started_callbacks",
-            ),
-            (
-                "add_match_ended_callback",
-                "remove_match_ended_callback",
-                "_match_ended_callbacks",
-            ),
-        ],
-    )
-    def test_remove_callback(self, add_method: str, remove_method: str, list_attr: str) -> None:
-        """Test removing callbacks for each event type."""
+    def test_remove_player_info_callback(self) -> None:
+        """Test removing player info callback."""
         client = GSProClient()
         callback = MagicMock()
+        client.add_player_info_callback(callback)
+        client.remove_player_info_callback(callback)
+        assert callback not in client._player_info_callbacks
 
-        getattr(client, add_method)(callback)
-        getattr(client, remove_method)(callback)
+    def test_add_match_started_callback(self) -> None:
+        """Test adding match started callback."""
+        client = GSProClient()
+        callback = MagicMock()
+        client.add_match_started_callback(callback)
+        assert callback in client._match_started_callbacks
 
-        assert callback not in getattr(client, list_attr)
+    def test_remove_match_started_callback(self) -> None:
+        """Test removing match started callback."""
+        client = GSProClient()
+        callback = MagicMock()
+        client.add_match_started_callback(callback)
+        client.remove_match_started_callback(callback)
+        assert callback not in client._match_started_callbacks
+
+    def test_add_match_ended_callback(self) -> None:
+        """Test adding match ended callback."""
+        client = GSProClient()
+        callback = MagicMock()
+        client.add_match_ended_callback(callback)
+        assert callback in client._match_ended_callbacks
+
+    def test_remove_match_ended_callback(self) -> None:
+        """Test removing match ended callback."""
+        client = GSProClient()
+        callback = MagicMock()
+        client.add_match_ended_callback(callback)
+        client.remove_match_ended_callback(callback)
+        assert callback not in client._match_ended_callbacks
 
     def test_remove_nonexistent_callback_no_error(self) -> None:
         """Test removing a callback that was never added doesn't raise."""
@@ -235,276 +212,198 @@ class TestHandleResponse:
         client._handle_response(response)
 
 
-class TestReaderLoopControl:
-    """Test starting and stopping the reader loop."""
+class TestDrainBuffer:
+    """Test the _drain_buffer method."""
 
-    def test_start_reader_loop_sets_running_flag(self) -> None:
-        """Test starting reader loop sets the running flag."""
+    def test_drain_buffer_processes_single_object(self) -> None:
+        """Test that _drain_buffer processes a single JSON object."""
         client = GSProClient()
-        client._connected = True
-        client._socket = MagicMock()
+        responses = []
+        client.add_response_callback(lambda r: responses.append(r))
 
-        # We need to mock the async task creation
-        with patch("asyncio.create_task") as mock_create_task:
-            mock_task = MagicMock()
-            mock_create_task.return_value = mock_task
+        data = json.dumps({"Code": 200, "Message": "OK"}).encode("utf-8")
+        remainder = client._drain_buffer(data)
 
-            client._start_reader_loop()
+        assert len(responses) == 1
+        assert responses[0].Code == 200
+        assert remainder == b""
 
-            assert client._reader_running is True
-            assert client._reader_task is mock_task
-
-    def test_stop_reader_loop_clears_running_flag(self) -> None:
-        """Test stopping reader loop clears the running flag."""
+    def test_drain_buffer_processes_multiple_objects(self) -> None:
+        """Test that _drain_buffer processes multiple JSON objects."""
         client = GSProClient()
-        client._reader_running = True
-        mock_task = MagicMock()
-        client._reader_task = mock_task
+        responses = []
+        client.add_response_callback(lambda r: responses.append(r))
 
-        client._stop_reader_loop()
+        data = json.dumps({"Code": 200, "Message": "OK"}).encode("utf-8") + json.dumps(
+            {"Code": 201, "Message": "Player", "Player": {}}
+        ).encode("utf-8")
+        remainder = client._drain_buffer(data)
 
-        assert client._reader_running is False
-        mock_task.cancel.assert_called_once()
-        assert client._reader_task is None
+        assert len(responses) == 2
+        assert remainder == b""
 
-    def test_stop_reader_loop_when_not_running(self) -> None:
-        """Test stopping reader loop when not running is safe."""
+    def test_drain_buffer_returns_incomplete_json(self) -> None:
+        """Test that _drain_buffer returns incomplete JSON."""
         client = GSProClient()
-        client._reader_running = False
-        client._reader_task = None
+        incomplete = b'{"Code": 200, "Mes'
+        remainder = client._drain_buffer(incomplete)
+        assert remainder == incomplete
 
-        # Should not raise
-        client._stop_reader_loop()
-
-        assert client._reader_running is False
-
-    def test_start_reader_loop_already_running(self) -> None:
-        """Test starting reader loop when already running doesn't create new task."""
+    def test_drain_buffer_handles_gspro_ready_string(self) -> None:
+        """Test that _drain_buffer handles bare 'GSPro ready' string."""
         client = GSProClient()
-        client._connected = True
-        client._socket = MagicMock()
 
-        existing_task = MagicMock()
-        existing_task.done.return_value = False
-        client._reader_task = existing_task
-        client._reader_running = True
+        with (
+            patch.object(client, "_start_heartbeat_timer"),
+            patch.object(client, "_schedule_heartbeat"),
+        ):
+            remainder = client._drain_buffer(b"GSPro ready\n")
 
-        with patch("asyncio.create_task") as mock_create_task:
-            client._start_reader_loop()
+        assert client.match_started is True
+        assert remainder == b""
 
-            # Should not create new task since one is running
-            mock_create_task.assert_not_called()
+    def test_drain_buffer_handles_gspro_ready_as_code_202(self) -> None:
+        """Test that 'GSPro ready' triggers match started callbacks."""
+        client = GSProClient()
+        callback = MagicMock()
+        client.add_match_started_callback(callback)
+
+        with (
+            patch.object(client, "_start_heartbeat_timer"),
+            patch.object(client, "_schedule_heartbeat"),
+        ):
+            client._drain_buffer(b"GSPro ready\n")
+
+        callback.assert_called()
+
+    def test_drain_buffer_handles_newline_terminated_json(self) -> None:
+        """Test that _drain_buffer handles newline-terminated JSON."""
+        client = GSProClient()
+        responses = []
+        client.add_response_callback(lambda r: responses.append(r))
+
+        data = json.dumps({"Code": 200, "Message": "OK"}).encode("utf-8") + b"\n"
+        remainder = client._drain_buffer(data)
+
+        assert len(responses) == 1
+        assert remainder == b""
 
 
 class TestReaderLoop:
-    """Test the reader loop behavior."""
+    """Test the async reader loop behavior."""
 
     @pytest.mark.asyncio
-    async def test_reader_loop_processes_single_json_object(
-        self, connected_client: GSProClient
-    ) -> None:
-        """Test reader loop processes a single JSON object."""
-        callback = MagicMock()
-        connected_client.add_match_started_callback(callback)
-
-        response = json.dumps({"Code": 202, "Message": "GSPro is Ready"}).encode()
-        mock_socket = get_mock_socket(connected_client)
-        mock_socket.recv.side_effect = create_socket_recv_sequence(connected_client, response)
+    async def test_reader_loop_stops_on_eof(self, connected_client: GSProClient) -> None:
+        """Test reader loop stops when reader returns empty bytes (EOF)."""
+        mock_reader = AsyncMock()
+        mock_reader.read = AsyncMock(return_value=b"")
+        connected_client._reader = mock_reader
 
         await connected_client._reader_loop()
 
-        callback.assert_called_once()
+        # EOF detected, connection marked as lost
+        assert connected_client.is_connected is False
 
     @pytest.mark.asyncio
-    async def test_reader_loop_handles_multiple_json_objects(
-        self, connected_client: GSProClient
-    ) -> None:
-        """Test reader loop processes multiple JSON objects in one read."""
-        callback_202 = MagicMock()
-        callback_201 = MagicMock()
-        connected_client.add_match_started_callback(callback_202)
-        connected_client.add_player_info_callback(callback_201)
+    async def test_reader_loop_processes_response(self, connected_client: GSProClient) -> None:
+        """Test reader loop processes a JSON response."""
+        responses = []
+        connected_client.add_response_callback(lambda r: responses.append(r))
 
-        response1 = {"Code": 202, "Message": "GSPro is Ready"}
-        response2 = {"Code": 201, "Player": {"Club": "DR"}}
-        combined = (json.dumps(response1) + json.dumps(response2)).encode()
-        mock_socket = get_mock_socket(connected_client)
-        mock_socket.recv.side_effect = create_socket_recv_sequence(connected_client, combined)
-
-        await connected_client._reader_loop()
-
-        callback_202.assert_called_once()
-        callback_201.assert_called_once_with({"Club": "DR"})
-
-    @pytest.mark.asyncio
-    async def test_reader_loop_handles_incomplete_json(self, connected_client: GSProClient) -> None:
-        """Test reader loop buffers incomplete JSON until complete."""
-        callback = MagicMock()
-        connected_client.add_match_started_callback(callback)
-
-        full_json = json.dumps({"Code": 202, "Message": "GSPro is Ready"})
-        part1 = full_json[:10].encode()
-        part2 = full_json[10:].encode()
-        mock_socket = get_mock_socket(connected_client)
-        mock_socket.recv.side_effect = create_socket_recv_sequence(connected_client, part1, part2)
-
-        await connected_client._reader_loop()
-
-        callback.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_reader_loop_stops_on_connection_closed(
-        self, connected_client: GSProClient
-    ) -> None:
-        """Test reader loop stops when connection is closed (empty recv)."""
-        mock_socket = get_mock_socket(connected_client)
-        mock_socket.recv.return_value = b""
-
-        await connected_client._reader_loop()
-        # If we get here, loop exited properly
-
-    @pytest.mark.asyncio
-    async def test_reader_loop_stops_on_socket_error(self, connected_client: GSProClient) -> None:
-        """Test reader loop stops gracefully on socket error."""
-        mock_socket = get_mock_socket(connected_client)
-        mock_socket.recv.side_effect = OSError("Connection reset")
-
-        await connected_client._reader_loop()
-        # If we get here, loop exited properly without raising
-
-    @pytest.mark.asyncio
-    async def test_reader_loop_stops_when_running_flag_cleared(
-        self, connected_client: GSProClient
-    ) -> None:
-        """Test reader loop stops when running flag is cleared."""
+        data = json.dumps({"Code": 200, "Message": "OK"}).encode("utf-8")
         call_count = 0
 
-        def recv_side_effect(_size: int) -> bytes:
+        async def mock_read(_n: int) -> bytes:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                connected_client._reader_running = False
-            raise BlockingIOError()
+                return data
+            else:
+                connected_client._connected = False
+                return b""
 
-        mock_socket = get_mock_socket(connected_client)
-        mock_socket.recv.side_effect = recv_side_effect
+        mock_reader = MagicMock()
+        mock_reader.read = mock_read
+        connected_client._reader = mock_reader
 
         await connected_client._reader_loop()
 
-        assert call_count >= 1
+        assert len(responses) == 1
+        assert responses[0].Code == 200
+
+    @pytest.mark.asyncio
+    async def test_reader_loop_stops_on_connection_error(
+        self, connected_client: GSProClient
+    ) -> None:
+        """Test reader loop stops on connection error."""
+        mock_reader = MagicMock()
+        mock_reader.read = AsyncMock(side_effect=OSError("Connection reset"))
+        connected_client._reader = mock_reader
+
+        await connected_client._reader_loop()
+
+        # Should have exited cleanly and marked disconnected
+        assert connected_client.is_connected is False
 
     @pytest.mark.asyncio
     async def test_reader_loop_stops_when_disconnected(self, connected_client: GSProClient) -> None:
-        """Test reader loop stops when client is disconnected."""
-        call_count = 0
+        """Test reader loop stops when _connected becomes False."""
+        connected_client._connected = False
+        mock_reader = MagicMock()
+        mock_reader.read = AsyncMock(return_value=b"")
+        connected_client._reader = mock_reader
 
-        def recv_side_effect(_size: int) -> bytes:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                connected_client._connected = False
-            raise BlockingIOError()
+        # Should return immediately since _connected is False
+        await connected_client._reader_loop()
 
-        mock_socket = get_mock_socket(connected_client)
-        mock_socket.recv.side_effect = recv_side_effect
+    @pytest.mark.asyncio
+    async def test_reader_loop_triggers_disconnect_callback_on_eof(
+        self, connected_client: GSProClient
+    ) -> None:
+        """Test reader loop calls disconnect callbacks on EOF."""
+        disconnect_callback = MagicMock()
+        connected_client.add_disconnect_callback(disconnect_callback)
+
+        mock_reader = MagicMock()
+        mock_reader.read = AsyncMock(return_value=b"")
+        connected_client._reader = mock_reader
 
         await connected_client._reader_loop()
 
-        assert call_count >= 1
+        disconnect_callback.assert_called_once()
 
 
 class TestConnectWithReaderLoop:
-    """Test that connect starts the reader loop."""
-
-    def test_connect_starts_reader_loop(self) -> None:
-        """Test that successful connect starts the reader loop."""
-        client = GSProClient()
-
-        with (
-            patch("socket.create_connection") as mock_create,
-            patch.object(client, "_start_reader_loop") as mock_start_reader,
-            patch.object(client, "send_heartbeat"),
-        ):
-            mock_socket = MagicMock()
-            mock_create.return_value = mock_socket
-
-            result = client.connect()
-
-            assert result is True
-            mock_start_reader.assert_called_once()
-
-    def test_connect_failure_doesnt_start_reader(self) -> None:
-        """Test that failed connect doesn't start the reader loop."""
-        client = GSProClient()
-
-        with (
-            patch("socket.create_connection") as mock_create,
-            patch.object(client, "_start_reader_loop") as mock_start_reader,
-        ):
-            mock_create.side_effect = OSError("Connection refused")
-
-            result = client.connect()
-
-            assert result is False
-            mock_start_reader.assert_not_called()
-
-
-class TestDisconnectWithReaderLoop:
-    """Test that disconnect stops the reader loop."""
-
-    def test_disconnect_stops_reader_loop(self) -> None:
-        """Test that disconnect stops the reader loop."""
-        client = GSProClient()
-        client._connected = True
-        client._socket = MagicMock()
-
-        with patch.object(client, "_stop_reader_loop") as mock_stop_reader:
-            client.disconnect()
-
-            mock_stop_reader.assert_called_once()
-
-    def test_disconnect_stops_reader_before_shutdown_heartbeat(self) -> None:
-        """Test that reader is stopped before shutdown heartbeat is sent."""
-        client = GSProClient()
-        client._connected = True
-        mock_socket = MagicMock()
-        client._socket = mock_socket
-
-        call_order: list[str] = []
-
-        def record_stop() -> None:
-            call_order.append("stop_reader")
-
-        def record_send(*_args: Any, **_kwargs: Any) -> None:
-            call_order.append("send_heartbeat")
-
-        with (
-            patch.object(client, "_stop_reader_loop", side_effect=record_stop),
-            patch.object(client, "_send_shutdown_heartbeat", side_effect=record_send),
-        ):
-            client.disconnect()
-
-            # Reader should be stopped before heartbeat is sent
-            assert call_order == ["stop_reader", "send_heartbeat"]
-
-
-class TestAsyncConnectWithReaderLoop:
-    """Test async connect with reader loop."""
+    """Test that async connect starts the reader loop."""
 
     @pytest.mark.asyncio
-    async def test_connect_async_starts_reader_loop(self) -> None:
-        """Test that async connect starts the reader loop."""
+    async def test_connect_creates_reader_task(self) -> None:
+        """Test that successful connect creates a reader task."""
         client = GSProClient()
+        mock_reader = MagicMock()
+        mock_writer = MagicMock()
+        mock_writer.drain = AsyncMock()
+        mock_writer.write = MagicMock()
+        mock_writer.close = MagicMock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_writer.get_extra_info = MagicMock(return_value=None)
 
         with (
-            patch("socket.create_connection") as mock_create,
-            patch.object(client, "_start_reader_loop") as mock_start_reader,
-            patch.object(client, "send_heartbeat"),
+            patch("asyncio.open_connection", return_value=(mock_reader, mock_writer)),
+            patch.object(client, "_reader_loop", new=AsyncMock()),
         ):
-            mock_socket = MagicMock()
-            mock_create.return_value = mock_socket
+            result = await client.connect()
 
-            result = await client.connect_async()
+        assert result is True
+        assert client._reader_task is not None
 
-            assert result is True
-            mock_start_reader.assert_called_once()
+    @pytest.mark.asyncio
+    async def test_connect_failure_doesnt_create_reader_task(self) -> None:
+        """Test that failed connect doesn't create a reader task."""
+        client = GSProClient()
+
+        with patch("asyncio.open_connection", side_effect=OSError("Connection refused")):
+            result = await client.connect()
+
+        assert result is False
+        assert client._reader_task is None

--- a/tests/unit/test_reconnect_manager.py
+++ b/tests/unit/test_reconnect_manager.py
@@ -1,0 +1,60 @@
+# ABOUTME: Unit tests for ReconnectionManager exponential-backoff reconnect helper.
+# ABOUTME: Covers retry-count semantics, infinite-retry mode, cancellation, and delay calculation.
+"""Unit tests for ReconnectionManager."""
+
+from __future__ import annotations
+
+import pytest
+
+from gc2_connect.utils.reconnect import ReconnectionManager, ReconnectionState
+
+
+class TestInfiniteRetries:
+    """Test that max_retries=None means infinite retries."""
+
+    @pytest.mark.asyncio
+    async def test_infinite_retries_keeps_attempting_past_default_cap(self) -> None:
+        """When max_retries=None the loop should keep attempting beyond any normal cap."""
+        mgr = ReconnectionManager(max_retries=None, base_delay=0.0, max_delay=0.0)
+        attempts = 0
+
+        def fail_then_succeed() -> bool:
+            nonlocal attempts
+            attempts += 1
+            return attempts >= 50  # success on the 50th attempt
+
+        result = await mgr.attempt_reconnect(fail_then_succeed)
+        assert result is True
+        assert attempts == 50
+        assert mgr.state == ReconnectionState.CONNECTED
+
+    @pytest.mark.asyncio
+    async def test_infinite_retries_stops_on_cancel(self) -> None:
+        """When max_retries=None the loop should stop when cancel() is called."""
+        mgr = ReconnectionManager(max_retries=None, base_delay=0.0, max_delay=0.0)
+        attempts = 0
+
+        def fail_and_cancel_after_3() -> bool:
+            nonlocal attempts
+            attempts += 1
+            if attempts >= 3:
+                mgr.cancel()
+            return False
+
+        result = await mgr.attempt_reconnect(fail_and_cancel_after_3)
+        assert result is False
+        assert mgr.state == ReconnectionState.DISCONNECTED
+        assert attempts == 3
+
+    @pytest.mark.asyncio
+    async def test_finite_retries_still_exits_at_max(self) -> None:
+        """Confirm we did not regress the bounded-retry path: max_retries=3 still exits."""
+        mgr = ReconnectionManager(max_retries=3, base_delay=0.0, max_delay=0.0)
+
+        def always_fail() -> bool:
+            return False
+
+        result = await mgr.attempt_reconnect(always_fail)
+        assert result is False
+        assert mgr.state == ReconnectionState.FAILED
+        assert mgr.retry_count == 3

--- a/tests/unit/test_reconnect_manager.py
+++ b/tests/unit/test_reconnect_manager.py
@@ -58,3 +58,12 @@ class TestInfiniteRetries:
         assert result is False
         assert mgr.state == ReconnectionState.FAILED
         assert mgr.retry_count == 3
+
+
+class TestCappedBackoff:
+    """Test the 5s -> 60s capped exponential backoff used for GSPro."""
+
+    def test_gspro_backoff_sequence(self) -> None:
+        mgr = ReconnectionManager(max_retries=None, base_delay=5.0, max_delay=60.0)
+        delays = [mgr.get_delay_for_attempt(i) for i in range(7)]
+        assert delays == [5.0, 10.0, 20.0, 40.0, 60.0, 60.0, 60.0]

--- a/tests/unit/test_shot_router.py
+++ b/tests/unit/test_shot_router.py
@@ -161,12 +161,12 @@ class TestShotRouting:
     ) -> None:
         """Test that shots are routed to GSPro in GSPRO mode."""
         mock_client = MagicMock()
-        mock_client.send_shot_async = AsyncMock()
+        mock_client.send_shot = AsyncMock()
         shot_router.set_gspro_client(mock_client)
 
         await shot_router.route_shot(sample_shot)
 
-        mock_client.send_shot_async.assert_called_once_with(sample_shot)
+        mock_client.send_shot.assert_called_once_with(sample_shot)
 
     @pytest.mark.asyncio
     async def test_route_shot_open_range_mode_calls_engine(
@@ -276,7 +276,7 @@ class TestShotCallbacks:
     ) -> None:
         """Test that shot result callback is not called in GSPro mode."""
         mock_client = MagicMock()
-        mock_client.send_shot_async = AsyncMock()
+        mock_client.send_shot = AsyncMock()
         shot_router.set_gspro_client(mock_client)
 
         result_callback = AsyncMock()


### PR DESCRIPTION
## Summary

Modernize the GSPro TCP client and its reconnect behavior.

- **`ReconnectionManager`** now supports `max_retries=None` for indefinite retries (`98e5d51`).
- **`MockGSProServer`** had a latent hang in its `disconnect_after_shots` branch (didn't actually close the writer) and a single-`json.loads` reader that dropped batched messages — both fixed, plus three new test helpers (`received_raw_bytes`, `close_all_connections`, `send_raw_to_clients`) the new integration tests need (`8e50211`).
- **`GSProClient`** migrated from sync `socket.socket` + `run_in_executor` wrappers to native `asyncio.StreamReader`/`StreamWriter` via `asyncio.open_connection`. All `send_*` methods are now `async`; `send_shot` returns `None` (the GSPro ack flows through the existing response-callback path rather than synchronously from `_send_message`). Every outbound JSON write is `\n`-terminated, matching the GsProApi.cs reference. `SO_KEEPALIVE` enabled on connect with platform-appropriate idle/interval/count so dead-peer detection works (`ef29901`).
- **GSPro reconnect** defaults to `max_retries=None` with a 5s → 60s capped backoff. When GSPro restarts, sleeps, or vanishes, the client keeps trying indefinitely until the user disconnects manually (`73fe9a4`). USB-side reconnect policy unchanged.

Wire-format (`Code`-based responses, `IsHeartBeat` flag, sign conventions, `CarryDistance`, combined ball+club shot messages) is unchanged — this PR is operational/structural, not protocol-changing. The protocol doc at `docs/GSPRO_TCP_PROTOCOL.md` was rewritten earlier to reflect the actual GSPro v1.x wire format, sourced from `docs/GsProApi.cs` and the working implementation.

Design spec: `docs/superpowers/specs/2026-05-11-gspro-client-async-migration-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-11-gspro-client-async-migration.md`

## Test plan

- [x] `uv run pytest` — 1037 passed
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Manual smoke test: connect to mock GSPro server, fire shots, kill server mid-session, verify reconnect loop persists past 60s, restart server, verify auto-reconnect succeeds
- [x] Manual smoke test: hit Disconnect mid-reconnect, verify loop stops cleanly